### PR TITLE
Set generation from Smogon, mostly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,243 @@
+var rawFile = 'vgc2015-1760.json';
+var genFile = 'setdex_smogvgc.js';
+
+module.exports = function (grunt) {
+
+    // Since I want to avoid polluting the global namespace, we're going to eval all the datafiles in
+    // their own namespace. Global Namespace Pollution BAAAD!
+    var LevenWork = (function (grunt) {
+
+        var MOVES_FILE     = './move_data.js';
+        var ABILITIES_FILE = './ability_data.js';
+        var NATURES_FILE   = './nature_data.js';
+        var ITEMS_FILE     = './item_data.js';
+
+        var leven = require('levenshtein');
+        var $ = {
+            extend: require('jquery-extend')
+        };
+
+        var moves, abilities, natures, items;
+
+        eval(grunt.file.read(MOVES_FILE, 'utf8'));
+        eval(grunt.file.read(ABILITIES_FILE, 'utf8'));
+        eval(grunt.file.read(NATURES_FILE, 'utf8'));
+        eval(grunt.file.read(ITEMS_FILE, 'utf8'));
+
+        var moves     = Object.keys(MOVES_XY);
+        var abilities = ABILITIES_XY;
+        var natures   = Object.keys(NATURES);
+        var items     = ITEMS_XY;
+
+        // Let's stick some items into that ITEMS_XY array, since Mega Stones have a special function
+        // when it comes to forme-picking.
+        items = items.concat([
+            'Abomasite',
+            'Absolite',
+            'Aerodactylite',
+            'Aggronite',
+            'Alakazite',
+            'Altarianite',
+            'Ampharosite',
+            'Audinite',
+            'Banettite',
+            'Beedrillite',
+            'Blastoisinite',
+            'Blazikenite',
+            'Cameruptite',
+            'Charizardite X',
+            'Charizardite Y',
+            'Diancite',
+            'Galladite',
+            'Garchompite',
+            'Gardevoirite',
+            'Gengarite',
+            'Glalitite',
+            'Gyaradosite',
+            'Heracronite',
+            'Houndoominite',
+            'Kangaskhanite',
+            'Latiasite',
+            'Latiosite',
+            'Lopunnite',
+            'Lucarionite',
+            'Manectite',
+            'Mawilite',
+            'Medichamite',
+            'Metagrossite',
+            'Mewtwonite X',
+            'Mewtwonite Y',
+            'Pidgeotite',
+            'Pinsirite',
+            'Sablenite',
+            'Salamencite',
+            'Sceptilite',
+            'Scizorite',
+            'Sharpedonite',
+            'Slowbronite',
+            'Steelixite',
+            'Swampertite',
+            'Tyranitarite',
+            'Venusaurite'
+            ]);
+
+        function simpleLeven(inKey, ary) {
+            // We can do this with a sort like the one here, but that actually takes a lot longer -- we only 
+            // need the minimum value, soo...
+            // return ary.sort(function (a, b) {
+            //         return leven(inKey, a) - leven(inKey, b);
+            //     })[0];
+
+            var bestMatch = {
+                val: 'NOMATCH',
+                dist: Number.MAX_VALUE
+            }
+
+            function mangle(s) {
+                return s.replace(/\W/g, '').toLowerCase();
+            }
+
+            ary.forEach(function (a) {
+                var dist = leven(inKey, mangle(a));
+                if (dist < bestMatch.dist) {
+                    bestMatch.val = a;
+                    bestMatch.dist = dist;
+                }
+            });
+            if (bestMatch.dist < 3) {
+                return bestMatch.val;
+            }
+            // There weren't any sufficiently close matches, which happens a lot for (eg) status moves
+            return '';
+        }
+
+        return {
+            closestMove:    function (inKey) { return simpleLeven(inKey, moves); },
+            closestAbility: function (inKey) { return simpleLeven(inKey, abilities); },
+            closestNature:  function (inKey) { return simpleLeven(inKey, natures); },
+            closestItem:    function (inKey) { return simpleLeven(inKey, items); }
+        }
+    })(grunt);
+
+
+    grunt.initConfig({
+        http: {
+            smogon: {
+                options: {
+                    url: 'http://www.smogon.com/stats/2015-01/chaos/' + rawFile
+                },
+                dest: rawFile
+            }
+        }
+    });
+
+    function needsDownload(fn) {
+        return !grunt.file.exists(fn);
+    }
+
+    function optionalHttp() {
+        if (needsDownload(rawFile)) {
+            grunt.log.ok('File doesn\'t exist, downloading: ' + rawFile);
+            grunt.task.run('http');
+        } else {
+            grunt.log.ok('File exists, not downloading: ' + rawFile);
+        }
+    }
+
+    function getSimpleSorted(obj, max) {
+        if (!max) {
+            max = Object.keys(obj).length;
+        }
+
+        return Object.keys(obj).sort(function (a, b) {
+            return obj[b] - obj[a];
+        }).slice(0, max);
+    }
+
+    var spreadPattern = /([A-Za-z]+):(\d+)\/(\d+)\/(\d+)\/(\d+)\/(\d+)\/(\d+)/;
+    function parseSpread(spread) {
+        // JS regexp is SLOW.  Consider doing this with a simple series of splits instead.
+        // Pros: faster.  Cons: less nerd cred. Pros: It's an ugly regexp anyway
+        // Adamant:84/220/12/0/20/172
+        var rv = {
+                nature: 'Hardy',
+                evs: {
+                    hp: 0,
+                    at: 0,
+                    de: 0,
+                    sa: 0,
+                    sd: 0,
+                    sp: 0
+                }
+            };
+
+        var match = spread.match(spreadPattern);
+        if (match) {
+            rv = {
+                nature: match[1],
+                evs: {
+                    hp: parseInt(match[2]),
+                    at: parseInt(match[3]),
+                    de: parseInt(match[4]),
+                    sa: parseInt(match[5]),
+                    sd: parseInt(match[6]),
+                    sp: parseInt(match[7])
+                }
+            };
+        }
+        return rv;
+
+    }
+
+    function individualSet(pokeData) {
+        var spreadRaw = getSimpleSorted(pokeData.Spreads, 1)[0];
+        var spread = parseSpread(spreadRaw);
+
+        return { 
+            "Smogon VGC Paradigm": {
+                level:   50,
+                evs:     spread.evs,
+                nature:  LevenWork.closestNature(spread.nature),
+                ability: LevenWork.closestAbility(getSimpleSorted(pokeData.Abilities, 1)[0]),
+                item:    LevenWork.closestItem(getSimpleSorted(pokeData.Items, 1)[0]),
+                moves:   getSimpleSorted(pokeData.Moves, 4).map(function (a) { return LevenWork.closestMove(a); })
+            }
+        };
+    }
+
+    function findSets(fn) {
+        // This is the cheesy way to read valid JSON.
+        var data = {};
+        var sets = {};
+        try {
+            grunt.log.ok('Reading data file ' + fn);
+            data = require('./' + fn);
+        } catch (e) { 
+            grunt.log.error('Failed to require the data file: ' + fn);
+        }
+        
+        grunt.log.write('Processing sets');
+        for (var p in data.data) {
+            if (data.data.hasOwnProperty(p)) {
+                // p is the name of a Pokemon; the data's in data.data[p] (eg data["data"]["Abomasnow"])
+                grunt.log.write('.');
+                sets[p] = individualSet(data.data[p]);
+            }
+        }
+        grunt.log.ok();
+
+        return sets;
+    }
+
+    function generateSetdex(raw, out) {
+        optionalHttp();
+        var sets = findSets(raw);
+        var outText = 'var SETDEX_XY=' + JSON.stringify(sets, null, 2) +';';
+        grunt.log.ok('Writing output to ' + genFile);
+        grunt.file.write(genFile, outText);
+    }
+
+    grunt.loadNpmTasks('grunt-http');
+
+    grunt.registerTask('default', 'Download if necessary', function () { generateSetdex(rawFile, genFile); });
+};

--- a/index.html
+++ b/index.html
@@ -321,7 +321,7 @@
     <script type="text/javascript" src="https://code.jquery.com/jquery-2.1.0.min.js"></script>
     <script type="text/javascript" src="./select2/select2.min.js"></script>
     <script type="text/javascript" src="./pokedex.js"></script>
-    <script type="text/javascript" src="./setdex_xy.js"></script>
+    <script type="text/javascript" src="./setdex_smogvgc.js"></script>
     <script type="text/javascript" src="./setdex_bw.js"></script>
     <script type="text/javascript" src="./setdex_dpp.js"></script>
     <script type="text/javascript" src="./setdex_rse.js"></script>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "gen6-damage-calc",
+  "version": "1.0.0",
+  "description": "VGC-specific fork of Honko and Gamut's Pokemon damage calculator",
+  "main": "index.html",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rushanshekar/gen6-damage-calc"
+  },
+  "keywords": [
+    "pokemon",
+    "vgc"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/rushanshekar/gen6-damage-calc/issues"
+  },
+  "homepage": "https://github.com/rushanshekar/gen6-damage-calc",
+  "devDependencies": {
+    "grunt": "~0.4.5",
+    "grunt-contrib-jshint": "~0.10.0",
+    "grunt-contrib-nodeunit": "~0.4.1",
+    "grunt-contrib-uglify": "~0.5.0",
+    "grunt-http": "^1.5.0",
+    "jquery-extend": "^2.0.3",
+    "levenshtein": "^1.0.5"
+  }
+}

--- a/setdex_bw.js
+++ b/setdex_bw.js
@@ -1,1 +1,1 @@
-var SETDEX_BW={"Abomasnow":{"Placeholder":{"level":50,"evs":{"hp":248,"sa":8,"sd":252},"nature":"Calm","ability":"Snow Warning","item":"Leftovers","moves":["Protect","Leech Seed","Grass Knot","Blizzard"]}}};
+var SETDEX_BW={};

--- a/setdex_dpp.js
+++ b/setdex_dpp.js
@@ -1,1 +1,1 @@
-var SETDEX_DPP={"Abomasnow":{"Placeholder":{"level":50,"evs":{"df":4,"hp":252,"sd":252},"nature":"Sassy","item":"Leftovers","moves":["Leech Seed","Protect","Wood Hammer","Blizzard"]}}};
+var SETDEX_DPP={};

--- a/setdex_gsc.js
+++ b/setdex_gsc.js
@@ -1,1 +1,1 @@
-var SETDEX_GSC={"Aerodactyl":{"Placeholder":{"level":50,"item":"Leftovers","moves":["Earthquake","Hidden Power Rock","Wing Attack","Fire Blast"]}}};
+var SETDEX_GSC={};

--- a/setdex_rby.js
+++ b/setdex_rby.js
@@ -1,1 +1,1 @@
-var SETDEX_RBY={"Alakazam":{"Placeholder":{"level":50,"moves":["Psychic","Recover","Thunder Wave","Reflect"]}}};
+var SETDEX_RBY={};

--- a/setdex_rse.js
+++ b/setdex_rse.js
@@ -1,1 +1,1 @@
-var SETDEX_ADV={"Absol":{"Placeholder":{"level":50,"evs":{"hp":252,"sp":216,"sa":40},"nature":"Timid","item":"Leftovers","moves":["Calm Mind","Thunderbolt","Ice Beam","Baton Pass"]}}};
+var SETDEX_ADV={};

--- a/setdex_smogvgc.js
+++ b/setdex_smogvgc.js
@@ -1,0 +1,6952 @@
+var SETDEX_XY={
+  "Porygon-Z": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "Adaptability",
+      "item": "Choice Scarf",
+      "moves": [
+        "Tri Attack",
+        "Ice Beam",
+        "Thunderbolt",
+        "Dark Pulse"
+      ]
+    }
+  },
+  "Mandibuzz": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 252,
+        "sa": 0,
+        "sd": 0,
+        "sp": 4
+      },
+      "nature": "Bold",
+      "ability": "Overcoat",
+      "item": "Leftovers",
+      "moves": [
+        "Foul Play",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Weezing": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 252,
+        "sa": 4,
+        "sd": 0,
+        "sp": 0
+      },
+      "nature": "Bold",
+      "ability": "Levitate",
+      "item": "Black Sludge",
+      "moves": [
+        "Sludge Bomb",
+        "Flamethrower",
+        "",
+        ""
+      ]
+    }
+  },
+  "Mantyke": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 108,
+        "sa": 0,
+        "sd": 148,
+        "sp": 0
+      },
+      "nature": "Calm",
+      "ability": "Water Absorb",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "",
+        "",
+        "Scald"
+      ]
+    }
+  },
+  "Swoobat": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "Simple",
+      "item": "",
+      "moves": [
+        "",
+        "Psychic",
+        "Stored Power",
+        "Air Slash"
+      ]
+    }
+  },
+  "Bronzong": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 228,
+        "sa": 0,
+        "sd": 28,
+        "sp": 0
+      },
+      "nature": "Relaxed",
+      "ability": "Levitate",
+      "item": "",
+      "moves": [
+        "",
+        "Gyro Ball",
+        "Rock Slide",
+        ""
+      ]
+    }
+  },
+  "Volcarona": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Modest",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "Bug Buzz",
+        "",
+        "Heat Wave",
+        ""
+      ]
+    }
+  },
+  "Thundurus": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Thunderbolt",
+        "",
+        "",
+        "Hidden Power Ice"
+      ]
+    }
+  },
+  "Spiritomb": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 124,
+        "sa": 132,
+        "sd": 0,
+        "sp": 0
+      },
+      "nature": "Relaxed",
+      "ability": "Infiltrator",
+      "item": "Assault Vest",
+      "moves": [
+        "Foul Play",
+        "",
+        "",
+        "Shadow Sneak"
+      ]
+    }
+  },
+  "Archeops": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "Defeatist",
+      "item": "",
+      "moves": [
+        "Rock Slide",
+        "",
+        "Earthquake",
+        "U-turn"
+      ]
+    }
+  },
+  "Stoutland": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Adamant",
+      "ability": "Sand Rush",
+      "item": "Choice Band",
+      "moves": [
+        "Play Rough",
+        "Return",
+        "Iron Head",
+        "Wild Charge"
+      ]
+    }
+  },
+  "Liepard": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 4,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "Fake Out",
+        "Foul Play",
+        ""
+      ]
+    }
+  },
+  "Purugly": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "Defiant",
+      "item": "Silk Scarf",
+      "moves": [
+        "",
+        "Fake Out",
+        "",
+        ""
+      ]
+    }
+  },
+  "Snorlax": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 252,
+        "sa": 0,
+        "sd": 0,
+        "sp": 0
+      },
+      "nature": "Brave",
+      "ability": "Thick Fat",
+      "item": "Assault Vest",
+      "moves": [
+        "Self-Destruct",
+        "Crunch",
+        "Double-Edge",
+        "Rock Slide"
+      ]
+    }
+  },
+  "Uxie": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 208,
+        "sa": 0,
+        "sd": 44,
+        "sp": 4
+      },
+      "nature": "Calm",
+      "ability": "Levitate",
+      "item": "Leftovers",
+      "moves": [
+        "",
+        "",
+        "",
+        "Foul Play"
+      ]
+    }
+  },
+  "Swellow": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "Guts",
+      "item": "Flame Orb",
+      "moves": [
+        "Brave Bird",
+        "Facade",
+        "",
+        "U-turn"
+      ]
+    }
+  },
+  "Kangaskhan": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "Scrappy",
+      "item": "Kangaskhanite",
+      "moves": [
+        "Fake Out",
+        "Sucker Punch",
+        "Double-Edge",
+        "Low Kick"
+      ]
+    }
+  },
+  "Ambipom": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "Technician",
+      "item": "Life Orb",
+      "moves": [
+        "Fake Out",
+        "",
+        "Double Hit",
+        "Return"
+      ]
+    }
+  },
+  "Hitmonlee": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 76,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 180
+      },
+      "nature": "Adamant",
+      "ability": "",
+      "item": "Normal Gem",
+      "moves": [
+        "Fake Out",
+        "Close Combat",
+        "Rock Slide",
+        ""
+      ]
+    }
+  },
+  "Magmortar": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Modest",
+      "ability": "",
+      "item": "Choice Scarf",
+      "moves": [
+        "Thunderbolt",
+        "Flamethrower",
+        "Heat Wave",
+        "Focus Blast"
+      ]
+    }
+  },
+  "Aron": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 84,
+        "at": 84,
+        "de": 0,
+        "sa": 84,
+        "sd": 84,
+        "sp": 84
+      },
+      "nature": "Sassy",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Poliwrath": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Adamant",
+      "ability": "Swift Swim",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Waterfall",
+        "Brick Break",
+        "",
+        ""
+      ]
+    }
+  },
+  "Machamp": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 220,
+        "at": 252,
+        "de": 36,
+        "sa": 0,
+        "sd": 0,
+        "sp": 0
+      },
+      "nature": "Adamant",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Dynamic Punch",
+        "",
+        "Ice Punch",
+        ""
+      ]
+    }
+  },
+  "Emolga": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 4,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "Motor Drive",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Druddigon": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 252,
+        "de": 4,
+        "sa": 0,
+        "sd": 0,
+        "sp": 0
+      },
+      "nature": "Adamant",
+      "ability": "",
+      "item": "Life Orb",
+      "moves": [
+        "Gunk Shot",
+        "Sucker Punch",
+        "Dragon Claw",
+        "Rock Slide"
+      ]
+    }
+  },
+  "Cacturne": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 160,
+        "at": 148,
+        "de": 0,
+        "sa": 200,
+        "sd": 0,
+        "sp": 0
+      },
+      "nature": "Brave",
+      "ability": "Water Absorb",
+      "item": "",
+      "moves": [
+        "Sucker Punch",
+        "Seed Bomb",
+        "Drain Punch",
+        ""
+      ]
+    }
+  },
+  "Raichu": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "Lightning Rod",
+      "item": "",
+      "moves": [
+        "Fake Out",
+        "",
+        "Thunderbolt",
+        ""
+      ]
+    }
+  },
+  "Musharna": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 244,
+        "at": 0,
+        "de": 164,
+        "sa": 0,
+        "sd": 100,
+        "sp": 0
+      },
+      "nature": "Sassy",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "",
+        "Psychic",
+        "",
+        ""
+      ]
+    }
+  },
+  "Cresselia": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 100,
+        "sa": 4,
+        "sd": 36,
+        "sp": 116
+      },
+      "nature": "Bold",
+      "ability": "Levitate",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Ice Beam",
+        "",
+        "Psychic",
+        ""
+      ]
+    }
+  },
+  "Roserade": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "Technician",
+      "item": "Black Sludge",
+      "moves": [
+        "Sludge Bomb",
+        "",
+        "Giga Drain",
+        "Leaf Storm"
+      ]
+    }
+  },
+  "Rampardos": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Adamant",
+      "ability": "Sheer Force",
+      "item": "Life Orb",
+      "moves": [
+        "Rock Slide",
+        "",
+        "Earthquake",
+        "Iron Head"
+      ]
+    }
+  },
+  "Tangela": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 248,
+        "at": 0,
+        "de": 0,
+        "sa": 0,
+        "sd": 224,
+        "sp": 36
+      },
+      "nature": "Calm",
+      "ability": "",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "",
+        "Giga Drain",
+        ""
+      ]
+    }
+  },
+  "Emboar": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 244,
+        "at": 164,
+        "de": 100,
+        "sa": 0,
+        "sd": 0,
+        "sp": 0
+      },
+      "nature": "Brave",
+      "ability": "Reckless",
+      "item": "Life Orb",
+      "moves": [
+        "Flare Blitz",
+        "Hammer Arm",
+        "Wild Charge",
+        ""
+      ]
+    }
+  },
+  "Chansey": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 248,
+        "at": 0,
+        "de": 252,
+        "sa": 0,
+        "sd": 8,
+        "sp": 0
+      },
+      "nature": "Bold",
+      "ability": "",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "Seismic Toss",
+        "",
+        ""
+      ]
+    }
+  },
+  "Blaziken": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 64,
+        "de": 0,
+        "sa": 196,
+        "sd": 0,
+        "sp": 244
+      },
+      "nature": "Naive",
+      "ability": "",
+      "item": "Life Orb",
+      "moves": [
+        "",
+        "Overheat",
+        "Low Kick",
+        "Hidden Power Ice"
+      ]
+    }
+  },
+  "Diggersby": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Adamant",
+      "ability": "Huge Power",
+      "item": "Choice Scarf",
+      "moves": [
+        "Earthquake",
+        "Return",
+        "Quick Attack",
+        ""
+      ]
+    }
+  },
+  "Rhydon": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 12,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 244,
+        "sp": 0
+      },
+      "nature": "Brave",
+      "ability": "Lightning Rod",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "Rock Slide",
+        "Earthquake",
+        "Ice Punch"
+      ]
+    }
+  },
+  "Exeggutor": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Modest",
+      "ability": "Chlorophyll",
+      "item": "Life Orb",
+      "moves": [
+        "",
+        "Psychic",
+        "Solar Beam",
+        "Hidden Power Ice"
+      ]
+    }
+  },
+  "Absol": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "",
+      "item": "Absolite",
+      "moves": [
+        "Sucker Punch",
+        "",
+        "Night Slash",
+        "Knock Off"
+      ]
+    }
+  },
+  "Garchomp": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "",
+      "item": "Life Orb",
+      "moves": [
+        "Earthquake",
+        "Rock Slide",
+        "Dragon Claw",
+        ""
+      ]
+    }
+  },
+  "Slurpuff": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Adamant",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "",
+        "Drain Punch",
+        "Play Rough",
+        ""
+      ]
+    }
+  },
+  "Ferrothorn": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 204,
+        "de": 0,
+        "sa": 0,
+        "sd": 52,
+        "sp": 0
+      },
+      "nature": "Brave",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "Power Whip",
+        "Gyro Ball",
+        ""
+      ]
+    }
+  },
+  "Cobalion": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "",
+      "item": "Life Orb",
+      "moves": [
+        "Iron Head",
+        "Close Combat",
+        "",
+        "Stone Edge"
+      ]
+    }
+  },
+  "Scrafty": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 248,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 8,
+        "sp": 0
+      },
+      "nature": "Adamant",
+      "ability": "Intimidate",
+      "item": "Assault Vest",
+      "moves": [
+        "Fake Out",
+        "Drain Punch",
+        "Knock Off",
+        "Crunch"
+      ]
+    }
+  },
+  "Milotic": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 248,
+        "at": 0,
+        "de": 252,
+        "sa": 8,
+        "sd": 0,
+        "sp": 0
+      },
+      "nature": "Bold",
+      "ability": "",
+      "item": "Leftovers",
+      "moves": [
+        "Scald",
+        "Ice Beam",
+        "Icy Wind",
+        ""
+      ]
+    }
+  },
+  "Sceptile": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "Overgrow",
+      "item": "Sceptilite",
+      "moves": [
+        "Dragon Pulse",
+        "",
+        "Leaf Storm",
+        "Focus Blast"
+      ]
+    }
+  },
+  "Aerodactyl": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "Unnerve",
+      "item": "",
+      "moves": [
+        "Rock Slide",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Eelektross": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 4,
+        "sp": 0
+      },
+      "nature": "Quiet",
+      "ability": "Levitate",
+      "item": "Assault Vest",
+      "moves": [
+        "Flamethrower",
+        "Thunderbolt",
+        "Giga Drain",
+        ""
+      ]
+    }
+  },
+  "Lilligant": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Modest",
+      "ability": "Chlorophyll",
+      "item": "Life Orb",
+      "moves": [
+        "",
+        "Giga Drain",
+        "",
+        ""
+      ]
+    }
+  },
+  "Hippowdon": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 188,
+        "at": 76,
+        "de": 100,
+        "sa": 0,
+        "sd": 140,
+        "sp": 4
+      },
+      "nature": "Impish",
+      "ability": "Sand Stream",
+      "item": "",
+      "moves": [
+        "Earthquake",
+        "",
+        "Ice Fang",
+        ""
+      ]
+    }
+  },
+  "Doublade": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 4,
+        "sa": 0,
+        "sd": 252,
+        "sp": 0
+      },
+      "nature": "Careful",
+      "ability": "",
+      "item": "Eviolite",
+      "moves": [
+        "Shadow Sneak",
+        "Iron Head",
+        "Sacred Sword",
+        ""
+      ]
+    }
+  },
+  "Latias": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "Levitate",
+      "item": "Latiasite",
+      "moves": [
+        "Draco Meteor",
+        "",
+        "Psyshock",
+        "Psychic"
+      ]
+    }
+  },
+  "Mesprit": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 152,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 0,
+        "sp": 104
+      },
+      "nature": "Modest",
+      "ability": "Levitate",
+      "item": "Colbur Berry",
+      "moves": [
+        "Psychic",
+        "Ice Beam",
+        "",
+        ""
+      ]
+    }
+  },
+  "Landorus-Therian": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Adamant",
+      "ability": "Intimidate",
+      "item": "Choice Scarf",
+      "moves": [
+        "Earthquake",
+        "Rock Slide",
+        "U-turn",
+        "Superpower"
+      ]
+    }
+  },
+  "Lapras": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 0,
+        "sa": 156,
+        "sd": 100,
+        "sp": 0
+      },
+      "nature": "Modest",
+      "ability": "Water Absorb",
+      "item": "Assault Vest",
+      "moves": [
+        "Freeze-Dry",
+        "Hydro Pump",
+        "Ice Shard",
+        ""
+      ]
+    }
+  },
+  "Bisharp": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Adamant",
+      "ability": "Defiant",
+      "item": "Life Orb",
+      "moves": [
+        "Sucker Punch",
+        "Iron Head",
+        "Knock Off",
+        ""
+      ]
+    }
+  },
+  "Pyroar": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "Unnerve",
+      "item": "Life Orb",
+      "moves": [
+        "Hyper Voice",
+        "Hidden Power Ice",
+        "",
+        "Overheat"
+      ]
+    }
+  },
+  "Zangoose": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 252,
+        "de": 4,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Adamant",
+      "ability": "Toxic Boost",
+      "item": "Toxic Orb",
+      "moves": [
+        "Facade",
+        "",
+        "Close Combat",
+        "Quick Attack"
+      ]
+    }
+  },
+  "Krookodile": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 60,
+        "sp": 192
+      },
+      "nature": "Adamant",
+      "ability": "Intimidate",
+      "item": "Choice Scarf",
+      "moves": [
+        "Earthquake",
+        "Rock Slide",
+        "Crunch",
+        "Knock Off"
+      ]
+    }
+  },
+  "Lucario": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "",
+      "item": "Lucarionite",
+      "moves": [
+        "Close Combat",
+        "",
+        "Bullet Punch",
+        ""
+      ]
+    }
+  },
+  "Throh": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 4,
+        "sa": 0,
+        "sd": 252,
+        "sp": 0
+      },
+      "nature": "Careful",
+      "ability": "",
+      "item": "Payapa Berry",
+      "moves": [
+        "",
+        "Storm Throw",
+        "",
+        "Stone Edge"
+      ]
+    }
+  },
+  "Dedenne": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 156,
+        "at": 0,
+        "de": 212,
+        "sa": 0,
+        "sd": 140,
+        "sp": 0
+      },
+      "nature": "Bold",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Mawile": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 4,
+        "sp": 0
+      },
+      "nature": "Adamant",
+      "ability": "Intimidate",
+      "item": "Mawilite",
+      "moves": [
+        "Play Rough",
+        "Sucker Punch",
+        "",
+        "Iron Head"
+      ]
+    }
+  },
+  "Gothorita": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 248,
+        "at": 0,
+        "de": 100,
+        "sa": 0,
+        "sd": 160,
+        "sp": 0
+      },
+      "nature": "Bold",
+      "ability": "",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Florges": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 252,
+        "sa": 4,
+        "sd": 0,
+        "sp": 0
+      },
+      "nature": "Bold",
+      "ability": "",
+      "item": "Leftovers",
+      "moves": [
+        "Moonblast",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Aurorus": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Modest",
+      "ability": "Refrigerate",
+      "item": "Life Orb",
+      "moves": [
+        "Hyper Voice",
+        "Earth Power",
+        "Freeze-Dry",
+        ""
+      ]
+    }
+  },
+  "Mantine": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 252,
+        "sa": 0,
+        "sd": 4,
+        "sp": 0
+      },
+      "nature": "Bold",
+      "ability": "Water Absorb",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Scald",
+        "",
+        "",
+        "Icy Wind"
+      ]
+    }
+  },
+  "Nidoqueen": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 172,
+        "at": 0,
+        "de": 0,
+        "sa": 236,
+        "sd": 0,
+        "sp": 100
+      },
+      "nature": "Modest",
+      "ability": "Sheer Force",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Earth Power",
+        "",
+        "Sludge Bomb",
+        ""
+      ]
+    }
+  },
+  "Cinccino": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "Skill Link",
+      "item": "Lum Berry",
+      "moves": [
+        "Rock Blast",
+        "",
+        "Bullet Seed",
+        ""
+      ]
+    }
+  },
+  "Altaria": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "Cloud Nine",
+      "item": "Altarianite",
+      "moves": [
+        "Hyper Voice",
+        "",
+        "",
+        "Draco Meteor"
+      ]
+    }
+  },
+  "Sharpedo": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Adamant",
+      "ability": "",
+      "item": "Sharpedonite",
+      "moves": [
+        "",
+        "Crunch",
+        "Waterfall",
+        "Ice Fang"
+      ]
+    }
+  },
+  "Torterra": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 212,
+        "de": 4,
+        "sa": 0,
+        "sd": 36,
+        "sp": 4
+      },
+      "nature": "Adamant",
+      "ability": "Overgrow",
+      "item": "Assault Vest",
+      "moves": [
+        "Earthquake",
+        "Wood Hammer",
+        "Stone Edge",
+        "Superpower"
+      ]
+    }
+  },
+  "Riolu": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 4,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "",
+      "item": "Choice Scarf",
+      "moves": [
+        "",
+        "",
+        "",
+        "Feint"
+      ]
+    }
+  },
+  "Leafeon": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 80,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 176
+      },
+      "nature": "Adamant",
+      "ability": "Chlorophyll",
+      "item": "Life Orb",
+      "moves": [
+        "Leaf Blade",
+        "Knock Off",
+        "",
+        "Frustration"
+      ]
+    }
+  },
+  "Aggron": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 4,
+        "sp": 0
+      },
+      "nature": "Brave",
+      "ability": "",
+      "item": "Aggronite",
+      "moves": [
+        "Earthquake",
+        "Iron Head",
+        "Head Smash",
+        "Rock Slide"
+      ]
+    }
+  },
+  "Togekiss": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 248,
+        "at": 0,
+        "de": 188,
+        "sa": 0,
+        "sd": 68,
+        "sp": 0
+      },
+      "nature": "Calm",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "",
+        "Air Slash",
+        "",
+        ""
+      ]
+    }
+  },
+  "Serperior": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "Contrary",
+      "item": "Life Orb",
+      "moves": [
+        "Leaf Storm",
+        "",
+        "Dragon Pulse",
+        "Hidden Power Rock"
+      ]
+    }
+  },
+  "Arcanine": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 0,
+        "sa": 72,
+        "sd": 124,
+        "sp": 60
+      },
+      "nature": "Calm",
+      "ability": "Intimidate",
+      "item": "Sitrus Berry",
+      "moves": [
+        "",
+        "Snarl",
+        "Extreme Speed",
+        "Heat Wave"
+      ]
+    }
+  },
+  "Omastar": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 12,
+        "at": 0,
+        "de": 4,
+        "sa": 236,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Modest",
+      "ability": "Swift Swim",
+      "item": "Life Orb",
+      "moves": [
+        "",
+        "Muddy Water",
+        "Ice Beam",
+        "Hydro Pump"
+      ]
+    }
+  },
+  "Mismagius": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Modest",
+      "ability": "Levitate",
+      "item": "",
+      "moves": [
+        "",
+        "Icy Wind",
+        "Energy Ball",
+        "Shadow Ball"
+      ]
+    }
+  },
+  "Scolipede": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 172,
+        "at": 168,
+        "de": 0,
+        "sa": 0,
+        "sd": 168,
+        "sp": 0
+      },
+      "nature": "Adamant",
+      "ability": "",
+      "item": "Black Sludge",
+      "moves": [
+        "",
+        "Poison Jab",
+        "",
+        "Megahorn"
+      ]
+    }
+  },
+  "Cofagrigus": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 0,
+        "sa": 4,
+        "sd": 252,
+        "sp": 0
+      },
+      "nature": "Sassy",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "Shadow Ball",
+        ""
+      ]
+    }
+  },
+  "Venusaur": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 52,
+        "sa": 4,
+        "sd": 4,
+        "sp": 196
+      },
+      "nature": "Calm",
+      "ability": "Chlorophyll",
+      "item": "Venusaurite",
+      "moves": [
+        "Sludge Bomb",
+        "Giga Drain",
+        "",
+        ""
+      ]
+    }
+  },
+  "Girafarig": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 112,
+        "at": 0,
+        "de": 196,
+        "sa": 0,
+        "sd": 196,
+        "sp": 0
+      },
+      "nature": "Timid",
+      "ability": "Sap Sipper",
+      "item": "Sitrus Berry",
+      "moves": [
+        "",
+        "",
+        "",
+        "Foul Play"
+      ]
+    }
+  },
+  "Golurk": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 248,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 8,
+        "sp": 0
+      },
+      "nature": "Brave",
+      "ability": "",
+      "item": "Assault Vest",
+      "moves": [
+        "Earthquake",
+        "Shadow Punch",
+        "Dynamic Punch",
+        ""
+      ]
+    }
+  },
+  "Heliolisk": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "Solar Power",
+      "item": "Choice Specs",
+      "moves": [
+        "Thunderbolt",
+        "Hyper Voice",
+        "Volt Switch",
+        "Hidden Power Ice"
+      ]
+    }
+  },
+  "Kingler": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Adamant",
+      "ability": "Hyper Cutter",
+      "item": "Choice Scarf",
+      "moves": [
+        "Crabhammer",
+        "Superpower",
+        "Rock Slide",
+        "X-Scissor"
+      ]
+    }
+  },
+  "Rhyperior": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 132,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 124,
+        "sp": 0
+      },
+      "nature": "Brave",
+      "ability": "Solid Rock",
+      "item": "",
+      "moves": [
+        "Rock Slide",
+        "",
+        "Earthquake",
+        "Hammer Arm"
+      ]
+    }
+  },
+  "Golem": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "",
+      "item": "Choice Scarf",
+      "moves": [
+        "Earthquake",
+        "Rock Slide",
+        "Explosion",
+        "Fire Punch"
+      ]
+    }
+  },
+  "Durant": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "Swarm",
+      "item": "Choice Band",
+      "moves": [
+        "Iron Head",
+        "Rock Slide",
+        "X-Scissor",
+        "Superpower"
+      ]
+    }
+  },
+  "Staraptor": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "Intimidate",
+      "item": "Choice Scarf",
+      "moves": [
+        "Brave Bird",
+        "Close Combat",
+        "U-turn",
+        ""
+      ]
+    }
+  },
+  "Meowstic": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 252,
+        "sa": 0,
+        "sd": 4,
+        "sp": 0
+      },
+      "nature": "Bold",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "Fake Out",
+        ""
+      ]
+    }
+  },
+  "Banette": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 60,
+        "sa": 0,
+        "sd": 196,
+        "sp": 0
+      },
+      "nature": "Calm",
+      "ability": "",
+      "item": "Banettite",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Beartic": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Adamant",
+      "ability": "Swift Swim",
+      "item": "Life Orb",
+      "moves": [
+        "Icicle Crash",
+        "Rock Slide",
+        "Superpower",
+        "Shadow Claw"
+      ]
+    }
+  },
+  "Cloyster": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Adamant",
+      "ability": "Skill Link",
+      "item": "",
+      "moves": [
+        "Icicle Spear",
+        "Rock Blast",
+        "",
+        ""
+      ]
+    }
+  },
+  "Pachirisu": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 252,
+        "sa": 0,
+        "sd": 4,
+        "sp": 0
+      },
+      "nature": "Impish",
+      "ability": "Volt Absorb",
+      "item": "Sitrus Berry",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Tauros": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "",
+      "item": "Life Orb",
+      "moves": [
+        "Earthquake",
+        "Rock Slide",
+        "Return",
+        ""
+      ]
+    }
+  },
+  "Klefki": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 248,
+        "at": 0,
+        "de": 252,
+        "sa": 0,
+        "sd": 8,
+        "sp": 0
+      },
+      "nature": "Bold",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "Foul Play",
+        "",
+        ""
+      ]
+    }
+  },
+  "Slowbro": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 124,
+        "sa": 0,
+        "sd": 132,
+        "sp": 0
+      },
+      "nature": "Relaxed",
+      "ability": "",
+      "item": "Slowbronite",
+      "moves": [
+        "Scald",
+        "",
+        "",
+        "Psychic"
+      ]
+    }
+  },
+  "Regirock": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 248,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 8,
+        "sp": 0
+      },
+      "nature": "Adamant",
+      "ability": "Clear Body",
+      "item": "Assault Vest",
+      "moves": [
+        "Rock Slide",
+        "Drain Punch",
+        "Ice Punch",
+        "Earthquake"
+      ]
+    }
+  },
+  "Kabutops": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Adamant",
+      "ability": "Swift Swim",
+      "item": "Life Orb",
+      "moves": [
+        "Waterfall",
+        "Rock Slide",
+        "",
+        "Knock Off"
+      ]
+    }
+  },
+  "Beedrill": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "Swarm",
+      "item": "Beedrillite",
+      "moves": [
+        "Poison Jab",
+        "",
+        "U-turn",
+        "Drill Run"
+      ]
+    }
+  },
+  "Raikou": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "",
+      "item": "Shuca Berry",
+      "moves": [
+        "Thunderbolt",
+        "Hidden Power Ice",
+        "Snarl",
+        ""
+      ]
+    }
+  },
+  "Salamence": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "Intimidate",
+      "item": "Salamencite",
+      "moves": [
+        "",
+        "Double-Edge",
+        "",
+        "Draco Meteor"
+      ]
+    }
+  },
+  "Greninja": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 220,
+        "at": 0,
+        "de": 28,
+        "sa": 4,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "Protean",
+      "item": "Life Orb",
+      "moves": [
+        "Ice Beam",
+        "",
+        "Low Kick",
+        "Dark Pulse"
+      ]
+    }
+  },
+  "Haxorus": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Adamant",
+      "ability": "Mold Breaker",
+      "item": "Lum Berry",
+      "moves": [
+        "Earthquake",
+        "Dragon Claw",
+        "",
+        ""
+      ]
+    }
+  },
+  "Seismitoad": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 176,
+        "at": 0,
+        "de": 0,
+        "sa": 140,
+        "sd": 0,
+        "sp": 192
+      },
+      "nature": "Modest",
+      "ability": "Water Absorb",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Earth Power",
+        "Scald",
+        "Icy Wind",
+        ""
+      ]
+    }
+  },
+  "Kecleon": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 156,
+        "de": 100,
+        "sa": 0,
+        "sd": 0,
+        "sp": 0
+      },
+      "nature": "Brave",
+      "ability": "Protean",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Fake Out",
+        "",
+        "Rock Slide",
+        "Drain Punch"
+      ]
+    }
+  },
+  "Marowak": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 4,
+        "sp": 0
+      },
+      "nature": "Brave",
+      "ability": "Lightning Rod",
+      "item": "Thick Club",
+      "moves": [
+        "Rock Slide",
+        "Bonemerang",
+        "",
+        "Knock Off"
+      ]
+    }
+  },
+  "Glaceon": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 4,
+        "sa": 248,
+        "sd": 0,
+        "sp": 4
+      },
+      "nature": "Modest",
+      "ability": "Snow Cloak",
+      "item": "Choice Specs",
+      "moves": [
+        "Blizzard",
+        "Shadow Ball",
+        "Ice Beam",
+        ""
+      ]
+    }
+  },
+  "Wigglytuff": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 4,
+        "sp": 0
+      },
+      "nature": "Quiet",
+      "ability": "",
+      "item": "Assault Vest",
+      "moves": [
+        "Dazzling Gleam",
+        "Flamethrower",
+        "",
+        "Hyper Voice"
+      ]
+    }
+  },
+  "Porygon2": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 244,
+        "at": 0,
+        "de": 156,
+        "sa": 0,
+        "sd": 108,
+        "sp": 0
+      },
+      "nature": "Relaxed",
+      "ability": "",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "Ice Beam",
+        "",
+        "Tri Attack"
+      ]
+    }
+  },
+  "Ampharos": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 248,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 8,
+        "sp": 0
+      },
+      "nature": "Quiet",
+      "ability": "",
+      "item": "Ampharosite",
+      "moves": [
+        "Dragon Pulse",
+        "",
+        "Thunderbolt",
+        "Focus Blast"
+      ]
+    }
+  },
+  "Crawdaunt": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 248,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 8,
+        "sp": 0
+      },
+      "nature": "Adamant",
+      "ability": "Adaptability",
+      "item": "Life Orb",
+      "moves": [
+        "Aqua Jet",
+        "Knock Off",
+        "Crabhammer",
+        ""
+      ]
+    }
+  },
+  "Crobat": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "Brave Bird",
+        "",
+        ""
+      ]
+    }
+  },
+  "Houndoom": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "Flash Fire",
+      "item": "Houndoominite",
+      "moves": [
+        "Dark Pulse",
+        "Heat Wave",
+        "",
+        "Solar Beam"
+      ]
+    }
+  },
+  "Mamoswine": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Adamant",
+      "ability": "Thick Fat",
+      "item": "Life Orb",
+      "moves": [
+        "Earthquake",
+        "Icicle Crash",
+        "Ice Shard",
+        ""
+      ]
+    }
+  },
+  "Goodra": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 20,
+        "sa": 204,
+        "sd": 28,
+        "sp": 4
+      },
+      "nature": "Bold",
+      "ability": "Sap Sipper",
+      "item": "Assault Vest",
+      "moves": [
+        "Draco Meteor",
+        "Fire Blast",
+        "Ice Beam",
+        "Thunderbolt"
+      ]
+    }
+  },
+  "Dusknoir": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 4,
+        "sa": 0,
+        "sd": 252,
+        "sp": 0
+      },
+      "nature": "Sassy",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        "Shadow Sneak"
+      ]
+    }
+  },
+  "Starmie": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "",
+      "item": "Choice Specs",
+      "moves": [
+        "Psyshock",
+        "Hydro Pump",
+        "Ice Beam",
+        "Thunderbolt"
+      ]
+    }
+  },
+  "Noivern": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 0,
+        "de": 4,
+        "sa": 244,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "",
+      "item": "Choice Specs",
+      "moves": [
+        "Draco Meteor",
+        "Flamethrower",
+        "",
+        ""
+      ]
+    }
+  },
+  "Persian": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 6,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "Technician",
+      "item": "",
+      "moves": [
+        "Icy Wind",
+        "Swift",
+        "",
+        "Hidden Power Fighting"
+      ]
+    }
+  },
+  "Infernape": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 252,
+        "de": 0,
+        "sa": 4,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Naive",
+      "ability": "Blaze",
+      "item": "",
+      "moves": [
+        "Fake Out",
+        "Close Combat",
+        "Overheat",
+        ""
+      ]
+    }
+  },
+  "Granbull": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 0
+      },
+      "nature": "Adamant",
+      "ability": "Intimidate",
+      "item": "Assault Vest",
+      "moves": [
+        "Play Rough",
+        "Close Combat",
+        "Wild Charge",
+        "Payback"
+      ]
+    }
+  },
+  "Floatzel": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Modest",
+      "ability": "Swift Swim",
+      "item": "Choice Scarf",
+      "moves": [
+        "Hydro Pump",
+        "",
+        "Focus Blast",
+        "Ice Beam"
+      ]
+    }
+  },
+  "Blissey": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 0,
+        "de": 252,
+        "sa": 244,
+        "sd": 4,
+        "sp": 4
+      },
+      "nature": "Bold",
+      "ability": "",
+      "item": "Kee Berry",
+      "moves": [
+        "",
+        "Ice Beam",
+        "",
+        ""
+      ]
+    }
+  },
+  "Politoed": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 244,
+        "at": 0,
+        "de": 124,
+        "sa": 132,
+        "sd": 4,
+        "sp": 4
+      },
+      "nature": "Calm",
+      "ability": "Drizzle",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Scald",
+        "",
+        "Ice Beam",
+        ""
+      ]
+    }
+  },
+  "Donphan": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 248,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 8,
+        "sp": 0
+      },
+      "nature": "Adamant",
+      "ability": "",
+      "item": "Choice Band",
+      "moves": [
+        "Earthquake",
+        "Ice Shard",
+        "Rock Slide",
+        "Gunk Shot"
+      ]
+    }
+  },
+  "Gothitelle": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 12,
+        "sa": 0,
+        "sd": 244,
+        "sp": 0
+      },
+      "nature": "Sassy",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "",
+        "",
+        "Psychic",
+        "Psyshock"
+      ]
+    }
+  },
+  "Primeape": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Adamant",
+      "ability": "Defiant",
+      "item": "Choice Scarf",
+      "moves": [
+        "Close Combat",
+        "Ice Punch",
+        "Gunk Shot",
+        "Rock Slide"
+      ]
+    }
+  },
+  "Metagross": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "Clear Body",
+      "item": "Metagrossite",
+      "moves": [
+        "Zen Headbutt",
+        "",
+        "Ice Punch",
+        "Iron Head"
+      ]
+    }
+  },
+  "Relicanth": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 252,
+        "sp": 0
+      },
+      "nature": "Brave",
+      "ability": "",
+      "item": "Choice Band",
+      "moves": [
+        "Head Smash",
+        "Waterfall",
+        "Rock Slide",
+        "Zen Headbutt"
+      ]
+    }
+  },
+  "Exploud": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 248,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 8,
+        "sp": 0
+      },
+      "nature": "Modest",
+      "ability": "Scrappy",
+      "item": "Choice Specs",
+      "moves": [
+        "Boomburst",
+        "Flamethrower",
+        "Ice Beam",
+        "Focus Blast"
+      ]
+    }
+  },
+  "Solosis": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 84,
+        "at": 84,
+        "de": 80,
+        "sa": 84,
+        "sd": 84,
+        "sp": 84
+      },
+      "nature": "Sassy",
+      "ability": "Magic Guard",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Sylveon": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 248,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 8,
+        "sp": 0
+      },
+      "nature": "Modest",
+      "ability": "Pixilate",
+      "item": "Choice Specs",
+      "moves": [
+        "Hyper Voice",
+        "Shadow Ball",
+        "Psyshock",
+        "Hyper Beam"
+      ]
+    }
+  },
+  "Hawlucha": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 252,
+        "de": 4,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Adamant",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "Acrobatics",
+        "High Jump Kick",
+        "Sky Attack",
+        ""
+      ]
+    }
+  },
+  "Hariyama": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 248,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 8,
+        "sp": 0
+      },
+      "nature": "Adamant",
+      "ability": "Guts",
+      "item": "Assault Vest",
+      "moves": [
+        "Close Combat",
+        "Fake Out",
+        "Knock Off",
+        "Ice Punch"
+      ]
+    }
+  },
+  "Lanturn": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 4,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "Volt Absorb",
+      "item": "Air Balloon",
+      "moves": [
+        "Ice Beam",
+        "Scald",
+        "",
+        "Spark"
+      ]
+    }
+  },
+  "Amoonguss": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 252,
+        "sa": 0,
+        "sd": 4,
+        "sp": 0
+      },
+      "nature": "Relaxed",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "Spark",
+        "",
+        "",
+        "Giga Drain"
+      ]
+    }
+  },
+  "Jolteon": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "Volt Absorb",
+      "item": "Choice Specs",
+      "moves": [
+        "Hidden Power Ice",
+        "Shadow Ball",
+        "Thunderbolt",
+        "Volt Switch"
+      ]
+    }
+  },
+  "Walrein": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 252,
+        "sa": 0,
+        "sd": 4,
+        "sp": 0
+      },
+      "nature": "Relaxed",
+      "ability": "Ice Body",
+      "item": "Leftovers",
+      "moves": [
+        "Blizzard",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Virizion": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "",
+      "item": "Life Orb",
+      "moves": [
+        "Leaf Blade",
+        "",
+        "Close Combat",
+        "Stone Edge"
+      ]
+    }
+  },
+  "Tornadus": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "",
+        "Hurricane",
+        "",
+        ""
+      ]
+    }
+  },
+  "Linoone": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 0,
+        "sa": 0,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "",
+        "",
+        "",
+        "Extreme Speed"
+      ]
+    }
+  },
+  "Misdreavus": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 92,
+        "at": 0,
+        "de": 68,
+        "sa": 4,
+        "sd": 196,
+        "sp": 148
+      },
+      "nature": "Calm",
+      "ability": "Levitate",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "",
+        "Icy Wind",
+        ""
+      ]
+    }
+  },
+  "Wobbuffet": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 0,
+        "de": 252,
+        "sa": 0,
+        "sd": 252,
+        "sp": 0
+      },
+      "nature": "Relaxed",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Maractus": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 248,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 8,
+        "sp": 0
+      },
+      "nature": "Quiet",
+      "ability": "Storm Drain",
+      "item": "",
+      "moves": [
+        "",
+        "Solar Beam",
+        "",
+        ""
+      ]
+    }
+  },
+  "Delphox": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "Heat Wave",
+        "Psychic",
+        "Psyshock",
+        ""
+      ]
+    }
+  },
+  "Golduck": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 172,
+        "at": 0,
+        "de": 12,
+        "sa": 116,
+        "sd": 4,
+        "sp": 204
+      },
+      "nature": "Timid",
+      "ability": "Cloud Nine",
+      "item": "Wacan Berry",
+      "moves": [
+        "Ice Beam",
+        "",
+        "Clear Smog",
+        "Scald"
+      ]
+    }
+  },
+  "Rotom-Wash": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 220,
+        "at": 0,
+        "de": 4,
+        "sa": 116,
+        "sd": 4,
+        "sp": 164
+      },
+      "nature": "Modest",
+      "ability": "Levitate",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Hydro Pump",
+        "Thunderbolt",
+        "",
+        ""
+      ]
+    }
+  },
+  "Chesnaught": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 4,
+        "sp": 0
+      },
+      "nature": "Adamant",
+      "ability": "Bulletproof",
+      "item": "Leftovers",
+      "moves": [
+        "Drain Punch",
+        "",
+        "Wood Hammer",
+        ""
+      ]
+    }
+  },
+  "Jumpluff": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 0,
+        "sa": 4,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "Infiltrator",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Avalugg": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 4,
+        "de": 252,
+        "sa": 0,
+        "sd": 0,
+        "sp": 0
+      },
+      "nature": "Relaxed",
+      "ability": "",
+      "item": "Leftovers",
+      "moves": [
+        "Avalanche",
+        "Earthquake",
+        "",
+        "Superpower"
+      ]
+    }
+  },
+  "Talonflame": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Adamant",
+      "ability": "",
+      "item": "Life Orb",
+      "moves": [
+        "Brave Bird",
+        "Flare Blitz",
+        "",
+        ""
+      ]
+    }
+  },
+  "Scyther": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 20,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 236
+      },
+      "nature": "Jolly",
+      "ability": "Technician",
+      "item": "Eviolite",
+      "moves": [
+        "Aerial Ace",
+        "Bug Bite",
+        "",
+        ""
+      ]
+    }
+  },
+  "Honchkrow": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 252,
+        "de": 0,
+        "sa": 4,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Hasty",
+      "ability": "",
+      "item": "Life Orb",
+      "moves": [
+        "Sucker Punch",
+        "Brave Bird",
+        "Superpower",
+        "Heat Wave"
+      ]
+    }
+  },
+  "Quagsire": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 248,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 8,
+        "sp": 0
+      },
+      "nature": "Adamant",
+      "ability": "Unaware",
+      "item": "Leftovers",
+      "moves": [
+        "Earthquake",
+        "",
+        "",
+        "Waterfall"
+      ]
+    }
+  },
+  "Lickilicky": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 4,
+        "sp": 0
+      },
+      "nature": "Adamant",
+      "ability": "",
+      "item": "Normal Gem",
+      "moves": [
+        "Explosion",
+        "Knock Off",
+        "",
+        ""
+      ]
+    }
+  },
+  "Sawsbuck": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 28,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 228
+      },
+      "nature": "Adamant",
+      "ability": "Sap Sipper",
+      "item": "Choice Scarf",
+      "moves": [
+        "Horn Leech",
+        "Jump Kick",
+        "Double-Edge",
+        "Wild Charge"
+      ]
+    }
+  },
+  "Magnezone": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "",
+      "item": "Choice Specs",
+      "moves": [
+        "Flash Cannon",
+        "Thunderbolt",
+        "Volt Switch",
+        "Hidden Power Ice"
+      ]
+    }
+  },
+  "Togetic": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 252,
+        "sa": 0,
+        "sd": 4,
+        "sp": 0
+      },
+      "nature": "Calm",
+      "ability": "",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "",
+        "Dazzling Gleam",
+        ""
+      ]
+    }
+  },
+  "Alakazam": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "Magic Guard",
+      "item": "",
+      "moves": [
+        "Psychic",
+        "Dazzling Gleam",
+        "Focus Blast",
+        "Shadow Ball"
+      ]
+    }
+  },
+  "Dragalge": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 148,
+        "at": 0,
+        "de": 108,
+        "sa": 252,
+        "sd": 0,
+        "sp": 0
+      },
+      "nature": "Modest",
+      "ability": "Adaptability",
+      "item": "Life Orb",
+      "moves": [
+        "Draco Meteor",
+        "Sludge Bomb",
+        "Dragon Pulse",
+        ""
+      ]
+    }
+  },
+  "Heracross": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 12,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 244
+      },
+      "nature": "Adamant",
+      "ability": "",
+      "item": "Heracronite",
+      "moves": [
+        "Close Combat",
+        "Pin Missile",
+        "Rock Blast",
+        ""
+      ]
+    }
+  },
+  "Blastoise": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 248,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 8,
+        "sp": 0
+      },
+      "nature": "Modest",
+      "ability": "Torrent",
+      "item": "Blastoisinite",
+      "moves": [
+        "Aura Sphere",
+        "Water Spout",
+        "",
+        "Ice Beam"
+      ]
+    }
+  },
+  "Gliscor": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 248,
+        "at": 0,
+        "de": 188,
+        "sa": 0,
+        "sd": 0,
+        "sp": 72
+      },
+      "nature": "Impish",
+      "ability": "Poison Heal",
+      "item": "Toxic Orb",
+      "moves": [
+        "Earthquake",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Toxicroak": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 4
+      },
+      "nature": "Adamant",
+      "ability": "Dry Skin",
+      "item": "Black Sludge",
+      "moves": [
+        "Drain Punch",
+        "Fake Out",
+        "Poison Jab",
+        "Sucker Punch"
+      ]
+    }
+  },
+  "Beheeyem": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 164,
+        "at": 0,
+        "de": 252,
+        "sa": 0,
+        "sd": 92,
+        "sp": 0
+      },
+      "nature": "Sassy",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "Psychic",
+        "",
+        ""
+      ]
+    }
+  },
+  "Carbink": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 6,
+        "at": 0,
+        "de": 252,
+        "sa": 0,
+        "sd": 252,
+        "sp": 0
+      },
+      "nature": "Relaxed",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        "Rock Slide"
+      ]
+    }
+  },
+  "Dragonite": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Adamant",
+      "ability": "Multiscale",
+      "item": "",
+      "moves": [
+        "Extreme Speed",
+        "Dragon Claw",
+        "",
+        "Earthquake"
+      ]
+    }
+  },
+  "Darmanitan": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 100,
+        "at": 252,
+        "de": 84,
+        "sa": 0,
+        "sd": 0,
+        "sp": 68
+      },
+      "nature": "Adamant",
+      "ability": "Sheer Force",
+      "item": "Life Orb",
+      "moves": [
+        "Flare Blitz",
+        "Rock Slide",
+        "",
+        "Superpower"
+      ]
+    }
+  },
+  "Gyarados": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Adamant",
+      "ability": "Intimidate",
+      "item": "Gyaradosite",
+      "moves": [
+        "Waterfall",
+        "",
+        "",
+        "Earthquake"
+      ]
+    }
+  },
+  "Rotom-Fan": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 240,
+        "at": 0,
+        "de": 188,
+        "sa": 0,
+        "sd": 80,
+        "sp": 0
+      },
+      "nature": "Modest",
+      "ability": "Levitate",
+      "item": "Leftovers",
+      "moves": [
+        "Air Slash",
+        "",
+        "Thunderbolt",
+        ""
+      ]
+    }
+  },
+  "Vileplume": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 4,
+        "sa": 252,
+        "sd": 0,
+        "sp": 0
+      },
+      "nature": "Quiet",
+      "ability": "",
+      "item": "Assault Vest",
+      "moves": [
+        "Sludge Bomb",
+        "Giga Drain",
+        "",
+        ""
+      ]
+    }
+  },
+  "Vaporeon": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 100,
+        "sa": 124,
+        "sd": 4,
+        "sp": 28
+      },
+      "nature": "Modest",
+      "ability": "Water Absorb",
+      "item": "Leftovers",
+      "moves": [
+        "Scald",
+        "",
+        "Ice Beam",
+        ""
+      ]
+    }
+  },
+  "Chandelure": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 4,
+        "sa": 252,
+        "sd": 0,
+        "sp": 0
+      },
+      "nature": "Quiet",
+      "ability": "Flash Fire",
+      "item": "",
+      "moves": [
+        "Shadow Ball",
+        "Heat Wave",
+        "",
+        ""
+      ]
+    }
+  },
+  "Pinsir": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "Hyper Cutter",
+      "item": "Pinsirite",
+      "moves": [
+        "Return",
+        "",
+        "Close Combat",
+        "Quick Attack"
+      ]
+    }
+  },
+  "Jigglypuff": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 248,
+        "at": 0,
+        "de": 0,
+        "sa": 8,
+        "sd": 252,
+        "sp": 0
+      },
+      "nature": "Calm",
+      "ability": "",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "",
+        "Dazzling Gleam",
+        ""
+      ]
+    }
+  },
+  "Froslass": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "Shadow Ball",
+        "Ice Beam",
+        ""
+      ]
+    }
+  },
+  "Reuniclus": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 4,
+        "sa": 252,
+        "sd": 0,
+        "sp": 0
+      },
+      "nature": "Quiet",
+      "ability": "Magic Guard",
+      "item": "Life Orb",
+      "moves": [
+        "",
+        "Psychic",
+        "",
+        "Psyshock"
+      ]
+    }
+  },
+  "Heatran": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "Flash Fire",
+      "item": "Leftovers",
+      "moves": [
+        "",
+        "Heat Wave",
+        "Earth Power",
+        ""
+      ]
+    }
+  },
+  "Ursaring": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 248,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 8,
+        "sp": 0
+      },
+      "nature": "Brave",
+      "ability": "Guts",
+      "item": "Toxic Orb",
+      "moves": [
+        "Facade",
+        "",
+        "Crunch",
+        "Hammer Arm"
+      ]
+    }
+  },
+  "Tyrantrum": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 248,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 8,
+        "sp": 0
+      },
+      "nature": "Adamant",
+      "ability": "Strong Jaw",
+      "item": "Choice Band",
+      "moves": [
+        "Rock Slide",
+        "Fire Fang",
+        "Dragon Claw",
+        "Crunch"
+      ]
+    }
+  },
+  "Klinklang": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 132,
+        "sa": 0,
+        "sd": 120,
+        "sp": 0
+      },
+      "nature": "Sassy",
+      "ability": "Clear Body",
+      "item": "",
+      "moves": [
+        "Gear Grind",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Pangoro": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 248,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 8,
+        "sp": 0
+      },
+      "nature": "Adamant",
+      "ability": "Iron Fist",
+      "item": "Life Orb",
+      "moves": [
+        "Knock Off",
+        "Gunk Shot",
+        "",
+        "Hammer Arm"
+      ]
+    }
+  },
+  "Terrakion": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "",
+      "item": "Lum Berry",
+      "moves": [
+        "Rock Slide",
+        "Close Combat",
+        "",
+        "Double Kick"
+      ]
+    }
+  },
+  "Gardevoir": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Modest",
+      "ability": "",
+      "item": "Gardevoirite",
+      "moves": [
+        "",
+        "Hyper Voice",
+        "Psychic",
+        "Psyshock"
+      ]
+    }
+  },
+  "Conkeldurr": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 248,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 8,
+        "sp": 0
+      },
+      "nature": "Adamant",
+      "ability": "Guts",
+      "item": "Assault Vest",
+      "moves": [
+        "Mach Punch",
+        "Drain Punch",
+        "Ice Punch",
+        "Knock Off"
+      ]
+    }
+  },
+  "Breloom": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "Technician",
+      "item": "",
+      "moves": [
+        "Spark",
+        "Bullet Seed",
+        "Mach Punch",
+        ""
+      ]
+    }
+  },
+  "Slowking": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 244,
+        "at": 0,
+        "de": 76,
+        "sa": 92,
+        "sd": 96,
+        "sp": 0
+      },
+      "nature": "Sassy",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "",
+        "Scald",
+        "Psychic",
+        ""
+      ]
+    }
+  },
+  "Drifblim": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 0,
+        "de": 252,
+        "sa": 0,
+        "sd": 252,
+        "sp": 0
+      },
+      "nature": "Bold",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Shadow Ball",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Articuno": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 0,
+        "sp": 0
+      },
+      "nature": "Bold",
+      "ability": "",
+      "item": "Charti Berry",
+      "moves": [
+        "Freeze-Dry",
+        "Hurricane",
+        "",
+        "Ice Beam"
+      ]
+    }
+  },
+  "Alomomola": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 4,
+        "sa": 0,
+        "sd": 252,
+        "sp": 0
+      },
+      "nature": "Calm",
+      "ability": "",
+      "item": "Leftovers",
+      "moves": [
+        "",
+        "Scald",
+        "",
+        "Icy Wind"
+      ]
+    }
+  },
+  "Hypno": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 252,
+        "sa": 0,
+        "sd": 4,
+        "sp": 0
+      },
+      "nature": "Relaxed",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        "Psychic"
+      ]
+    }
+  },
+  "Lopunny": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "",
+      "item": "Lopunnite",
+      "moves": [
+        "Fake Out",
+        "Return",
+        "High Jump Kick",
+        "Ice Punch"
+      ]
+    }
+  },
+  "Rotom-Mow": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 4,
+        "sa": 116,
+        "sd": 116,
+        "sp": 20
+      },
+      "nature": "Modest",
+      "ability": "Levitate",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Leaf Storm",
+        "Thunderbolt",
+        "",
+        ""
+      ]
+    }
+  },
+  "Audino": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 20,
+        "sa": 0,
+        "sd": 236,
+        "sp": 0
+      },
+      "nature": "Calm",
+      "ability": "",
+      "item": "Audinite",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Glalie": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Adamant",
+      "ability": "",
+      "item": "Glalitite",
+      "moves": [
+        "Explosion",
+        "",
+        "Earthquake",
+        "Return"
+      ]
+    }
+  },
+  "Drapion": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 196,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 60
+      },
+      "nature": "Adamant",
+      "ability": "Sniper",
+      "item": "Black Sludge",
+      "moves": [
+        "Cross Poison",
+        "Knock Off",
+        "",
+        "Night Slash"
+      ]
+    }
+  },
+  "Aromatisse": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 0,
+        "sa": 4,
+        "sd": 252,
+        "sp": 0
+      },
+      "nature": "Sassy",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "",
+        "",
+        "Moonblast",
+        ""
+      ]
+    }
+  },
+  "Torkoal": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 4,
+        "sp": 0
+      },
+      "nature": "Modest",
+      "ability": "Shell Armor",
+      "item": "Life Orb",
+      "moves": [
+        "",
+        "Heat Wave",
+        "Earth Power",
+        "Eruption"
+      ]
+    }
+  },
+  "Venomoth": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 132,
+        "sa": 0,
+        "sd": 120,
+        "sp": 0
+      },
+      "nature": "Bold",
+      "ability": "Tinted Lens",
+      "item": "Black Sludge",
+      "moves": [
+        "",
+        "",
+        "Bug Buzz",
+        ""
+      ]
+    }
+  },
+  "Excadrill": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Adamant",
+      "ability": "Sand Rush",
+      "item": "Life Orb",
+      "moves": [
+        "Iron Head",
+        "Rock Slide",
+        "Earthquake",
+        ""
+      ]
+    }
+  },
+  "Slaking": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "",
+      "item": "Life Orb",
+      "moves": [
+        "Earthquake",
+        "Return",
+        "Ice Punch",
+        "Rock Slide"
+      ]
+    }
+  },
+  "Smeargle": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 4,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        "Fake Out"
+      ]
+    }
+  },
+  "Whimsicott": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 4,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Spinda": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 4,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "Contrary",
+      "item": "Choice Scarf",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Rotom": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Hardy",
+      "ability": "Levitate",
+      "item": "Choice Specs",
+      "moves": [
+        "",
+        "Shadow Ball",
+        "Volt Switch",
+        "Dark Pulse"
+      ]
+    }
+  },
+  "Cradily": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 44,
+        "sa": 40,
+        "sd": 172,
+        "sp": 0
+      },
+      "nature": "Calm",
+      "ability": "Storm Drain",
+      "item": "Leftovers",
+      "moves": [
+        "Giga Drain",
+        "",
+        "Ancient Power",
+        "Earth Power"
+      ]
+    }
+  },
+  "Tangrowth": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 108,
+        "sa": 0,
+        "sd": 148,
+        "sp": 0
+      },
+      "nature": "Sassy",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "Leaf Storm",
+        "",
+        ""
+      ]
+    }
+  },
+  "Pidgeot": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "",
+      "item": "Pidgeotite",
+      "moves": [
+        "Hurricane",
+        "Heat Wave",
+        "",
+        ""
+      ]
+    }
+  },
+  "Regigigas": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 228,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 28
+      },
+      "nature": "Adamant",
+      "ability": "Slow Start",
+      "item": "Leftovers",
+      "moves": [
+        "Return",
+        "",
+        "Drain Punch",
+        ""
+      ]
+    }
+  },
+  "Tentacruel": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 4,
+        "sa": 0,
+        "sd": 252,
+        "sp": 0
+      },
+      "nature": "Calm",
+      "ability": "",
+      "item": "Black Sludge",
+      "moves": [
+        "Scald",
+        "Rapid Spin",
+        "Sludge Bomb",
+        "Sludge Wave"
+      ]
+    }
+  },
+  "Medicham": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "Pure Power",
+      "item": "Medichamite",
+      "moves": [
+        "Fake Out",
+        "Drain Punch",
+        "Psycho Cut",
+        "High Jump Kick"
+      ]
+    }
+  },
+  "Rotom-Frost": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Modest",
+      "ability": "Levitate",
+      "item": "Choice Scarf",
+      "moves": [
+        "Blizzard",
+        "Thunderbolt",
+        "Volt Switch",
+        ""
+      ]
+    }
+  },
+  "Sawk": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 28,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 228
+      },
+      "nature": "Adamant",
+      "ability": "",
+      "item": "Choice Scarf",
+      "moves": [
+        "Close Combat",
+        "Rock Slide",
+        "Poison Jab",
+        "Ice Punch"
+      ]
+    }
+  },
+  "Golbat": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 0
+      },
+      "nature": "Bold",
+      "ability": "",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Gengar": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "Levitate",
+      "item": "",
+      "moves": [
+        "Shadow Ball",
+        "",
+        "",
+        "Sludge Bomb"
+      ]
+    }
+  },
+  "Swampert": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 4,
+        "sa": 228,
+        "sd": 4,
+        "sp": 20
+      },
+      "nature": "Modest",
+      "ability": "Torrent",
+      "item": "Swampertite",
+      "moves": [
+        "",
+        "Earthquake",
+        "Waterfall",
+        ""
+      ]
+    }
+  },
+  "Spritzee": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 84,
+        "at": 84,
+        "de": 0,
+        "sa": 84,
+        "sd": 84,
+        "sp": 84
+      },
+      "nature": "Quiet",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Sableye": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 252,
+        "sa": 0,
+        "sd": 4,
+        "sp": 0
+      },
+      "nature": "Bold",
+      "ability": "",
+      "item": "Sablenite",
+      "moves": [
+        "",
+        "",
+        "",
+        "Foul Play"
+      ]
+    }
+  },
+  "Parasect": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 196,
+        "at": 0,
+        "de": 196,
+        "sa": 0,
+        "sd": 116,
+        "sp": 0
+      },
+      "nature": "Careful",
+      "ability": "Dry Skin",
+      "item": "",
+      "moves": [
+        "",
+        "Spark",
+        "",
+        "X-Scissor"
+      ]
+    }
+  },
+  "Dugtrio": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "Sucker Punch",
+        "",
+        "Earthquake",
+        "Rock Slide"
+      ]
+    }
+  },
+  "Typhlosion": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "Blaze",
+      "item": "Choice Scarf",
+      "moves": [
+        "Eruption",
+        "Focus Blast",
+        "Extrasensory",
+        "Heat Wave"
+      ]
+    }
+  },
+  "Braviary": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "Defiant",
+      "item": "Choice Scarf",
+      "moves": [
+        "Brave Bird",
+        "Superpower",
+        "Rock Slide",
+        "U-turn"
+      ]
+    }
+  },
+  "Electivire": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "Motor Drive",
+      "item": "Choice Scarf",
+      "moves": [
+        "Ice Punch",
+        "Earthquake",
+        "Cross Chop",
+        "Thunder Punch"
+      ]
+    }
+  },
+  "Suicune": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 196,
+        "at": 0,
+        "de": 0,
+        "sa": 100,
+        "sd": 0,
+        "sp": 212
+      },
+      "nature": "Modest",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Scald",
+        "Ice Beam",
+        "",
+        "Snarl"
+      ]
+    }
+  },
+  "Gourgeist-Super": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 244,
+        "at": 0,
+        "de": 252,
+        "sa": 0,
+        "sd": 12,
+        "sp": 0
+      },
+      "nature": "Relaxed",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "Seed Bomb",
+        ""
+      ]
+    }
+  },
+  "Scizor": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 248,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 8,
+        "sp": 0
+      },
+      "nature": "Adamant",
+      "ability": "Technician",
+      "item": "Life Orb",
+      "moves": [
+        "Bullet Punch",
+        "Bug Bite",
+        "",
+        ""
+      ]
+    }
+  },
+  "Manectric": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "Lightning Rod",
+      "item": "Manectite",
+      "moves": [
+        "",
+        "Hidden Power Ice",
+        "Volt Switch",
+        "Thunderbolt"
+      ]
+    }
+  },
+  "Nidoking": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "Sheer Force",
+      "item": "Life Orb",
+      "moves": [
+        "",
+        "Earth Power",
+        "Ice Beam",
+        "Poison Jab"
+      ]
+    }
+  },
+  "Zapdos": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 248,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 8,
+        "sp": 0
+      },
+      "nature": "Modest",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Thunderbolt",
+        "Hidden Power Ice",
+        "Heat Wave",
+        ""
+      ]
+    }
+  },
+  "Gourgeist-Small": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 248,
+        "at": 0,
+        "de": 4,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Vivillon": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 4,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Electrode": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 0,
+        "de": 4,
+        "sa": 244,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "Soundproof",
+      "item": "Air Balloon",
+      "moves": [
+        "",
+        "Discharge",
+        "Foul Play",
+        ""
+      ]
+    }
+  },
+  "Crustle": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 252,
+        "sa": 0,
+        "sd": 4,
+        "sp": 0
+      },
+      "nature": "Impish",
+      "ability": "",
+      "item": "Assault Vest",
+      "moves": [
+        "Knock Off",
+        "X-Scissor",
+        "Rock Slide",
+        "Earthquake"
+      ]
+    }
+  },
+  "Rapidash": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "Flash Fire",
+      "item": "Assault Vest",
+      "moves": [
+        "Flare Blitz",
+        "Drill Run",
+        "Wild Charge",
+        ""
+      ]
+    }
+  },
+  "Gourgeist": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 4,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "Explosion",
+        "",
+        ""
+      ]
+    }
+  },
+  "Gastrodon": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 116,
+        "sa": 108,
+        "sd": 28,
+        "sp": 4
+      },
+      "nature": "Calm",
+      "ability": "Storm Drain",
+      "item": "Rindo Berry",
+      "moves": [
+        "Earth Power",
+        "",
+        "Ice Beam",
+        "Scald"
+      ]
+    }
+  },
+  "Grumpig": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 4,
+        "sa": 252,
+        "sd": 0,
+        "sp": 0
+      },
+      "nature": "Modest",
+      "ability": "Thick Fat",
+      "item": "Assault Vest",
+      "moves": [
+        "Psyshock",
+        "Energy Ball",
+        "Power Gem",
+        "Icy Wind"
+      ]
+    }
+  },
+  "Moltres": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 212,
+        "at": 0,
+        "de": 0,
+        "sa": 140,
+        "sd": 56,
+        "sp": 100
+      },
+      "nature": "Modest",
+      "ability": "",
+      "item": "Charti Berry",
+      "moves": [
+        "",
+        "Heat Wave",
+        "",
+        ""
+      ]
+    }
+  },
+  "Thundurus-Therian": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Modest",
+      "ability": "Volt Absorb",
+      "item": "Choice Scarf",
+      "moves": [
+        "Hidden Power Ice",
+        "Thunderbolt",
+        "Volt Switch",
+        "Grass Knot"
+      ]
+    }
+  },
+  "Weavile": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "Fake Out",
+        "Knock Off",
+        "Low Kick",
+        "Ice Shard"
+      ]
+    }
+  },
+  "Tornadus-Therian": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "",
+      "item": "Life Orb",
+      "moves": [
+        "Hurricane",
+        "",
+        "Superpower",
+        "U-turn"
+      ]
+    }
+  },
+  "Furret": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 248,
+        "at": 0,
+        "de": 252,
+        "sa": 0,
+        "sd": 0,
+        "sp": 4
+      },
+      "nature": "Impish",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Gigalith": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 116,
+        "at": 168,
+        "de": 148,
+        "sa": 0,
+        "sd": 72,
+        "sp": 0
+      },
+      "nature": "Adamant",
+      "ability": "",
+      "item": "Assault Vest",
+      "moves": [
+        "Rock Slide",
+        "Earthquake",
+        "",
+        "Superpower"
+      ]
+    }
+  },
+  "Tyranitar": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 252,
+        "de": 4,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "Sand Stream",
+      "item": "Tyranitarite",
+      "moves": [
+        "Rock Slide",
+        "Crunch",
+        "",
+        "Low Kick"
+      ]
+    }
+  },
+  "Aegislash": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 4,
+        "sp": 0
+      },
+      "nature": "Quiet",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "Shadow Ball",
+        "Flash Cannon",
+        ""
+      ]
+    }
+  },
+  "Stantler": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 4,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "Intimidate",
+      "item": "",
+      "moves": [
+        "",
+        "Return",
+        "",
+        ""
+      ]
+    }
+  },
+  "Illumise": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 148,
+        "sa": 0,
+        "sd": 108,
+        "sp": 0
+      },
+      "nature": "Impish",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Registeel": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 148,
+        "de": 52,
+        "sa": 0,
+        "sd": 52,
+        "sp": 4
+      },
+      "nature": "Adamant",
+      "ability": "Clear Body",
+      "item": "",
+      "moves": [
+        "Iron Head",
+        "",
+        "Ice Punch",
+        "Superpower"
+      ]
+    }
+  },
+  "Dunsparce": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "",
+      "item": "Choice Scarf",
+      "moves": [
+        "Rock Slide",
+        "Drill Run",
+        "Double-Edge",
+        "Aqua Tail"
+      ]
+    }
+  },
+  "Empoleon": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 252,
+        "de": 4,
+        "sa": 0,
+        "sd": 0,
+        "sp": 0
+      },
+      "nature": "Brave",
+      "ability": "Torrent",
+      "item": "Life Orb",
+      "moves": [
+        "Flash Cannon",
+        "Scald",
+        "",
+        "Ice Beam"
+      ]
+    }
+  },
+  "Trevenant": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 244,
+        "at": 0,
+        "de": 100,
+        "sa": 0,
+        "sd": 164,
+        "sp": 0
+      },
+      "nature": "Sassy",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Horn Leech",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Ditto": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 248,
+        "at": 0,
+        "de": 252,
+        "sa": 0,
+        "sd": 8,
+        "sp": 0
+      },
+      "nature": "Bold",
+      "ability": "",
+      "item": "Choice Scarf",
+      "moves": [
+        "",
+        ""
+      ]
+    }
+  },
+  "Clamperl": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 68,
+        "sa": 184,
+        "sd": 4,
+        "sp": 0
+      },
+      "nature": "Relaxed",
+      "ability": "Shell Armor",
+      "item": "Deep Sea Tooth",
+      "moves": [
+        "",
+        "Ice Beam",
+        "Muddy Water",
+        "Hidden Power Fire"
+      ]
+    }
+  },
+  "Octillery": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 4,
+        "sp": 0
+      },
+      "nature": "Quiet",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "",
+        "Water Spout",
+        "Seed Bomb",
+        "Blizzard"
+      ]
+    }
+  },
+  "Electabuzz": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 252,
+        "sa": 0,
+        "sd": 4,
+        "sp": 0
+      },
+      "nature": "Bold",
+      "ability": "",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "",
+        "Feint",
+        ""
+      ]
+    }
+  },
+  "Charizard": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "Blaze",
+      "item": "Charizardite Y",
+      "moves": [
+        "",
+        "Heat Wave",
+        "Solar Beam",
+        "Overheat"
+      ]
+    }
+  },
+  "Xatu": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 124,
+        "sa": 0,
+        "sd": 128,
+        "sp": 0
+      },
+      "nature": "Bold",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "",
+        "Psychic",
+        "",
+        "Giga Drain"
+      ]
+    }
+  },
+  "Pikachu": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Adamant",
+      "ability": "Lightning Rod",
+      "item": "Light Ball",
+      "moves": [
+        "",
+        "Fake Out",
+        "Icicle Crash",
+        "Wild Charge"
+      ]
+    }
+  },
+  "Zoroark": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "Flamethrower",
+        "Night Daze",
+        "Sucker Punch",
+        "Focus Blast"
+      ]
+    }
+  },
+  "Accelgor": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 0,
+        "sa": 0,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        "Acid Spray"
+      ]
+    }
+  },
+  "Jynx": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "Dry Skin",
+      "item": "",
+      "moves": [
+        "Psychic",
+        "Blizzard",
+        "Fake Out",
+        ""
+      ]
+    }
+  },
+  "Shuckle": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 248,
+        "at": 0,
+        "de": 4,
+        "sa": 0,
+        "sd": 252,
+        "sp": 0
+      },
+      "nature": "Calm",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Umbreon": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 252,
+        "sa": 0,
+        "sd": 4,
+        "sp": 0
+      },
+      "nature": "Bold",
+      "ability": "",
+      "item": "Leftovers",
+      "moves": [
+        "Foul Play",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Galvantula": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "Bug Buzz",
+        "Thunder",
+        "",
+        ""
+      ]
+    }
+  },
+  "Abomasnow": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 4,
+        "de": 0,
+        "sa": 252,
+        "sd": 0,
+        "sp": 0
+      },
+      "nature": "Quiet",
+      "ability": "Snow Warning",
+      "item": "",
+      "moves": [
+        "Blizzard",
+        "",
+        "Ice Shard",
+        "Energy Ball"
+      ]
+    }
+  },
+  "Seaking": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 252,
+        "sa": 4,
+        "sd": 0,
+        "sp": 0
+      },
+      "nature": "Bold",
+      "ability": "Lightning Rod",
+      "item": "Leftovers",
+      "moves": [
+        "Ice Beam",
+        "",
+        "Scald",
+        ""
+      ]
+    }
+  },
+  "Dewgong": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 252,
+        "sa": 0,
+        "sd": 0,
+        "sp": 0
+      },
+      "nature": "Sassy",
+      "ability": "Thick Fat",
+      "item": "Leftovers",
+      "moves": [
+        "Fake Out",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Hitmonchan": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 4,
+        "sp": 0
+      },
+      "nature": "Adamant",
+      "ability": "Iron Fist",
+      "item": "Assault Vest",
+      "moves": [
+        "Ice Punch",
+        "Fake Out",
+        "Drain Punch",
+        "Bullet Punch"
+      ]
+    }
+  },
+  "Luxray": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 252,
+        "sa": 4,
+        "sd": 0,
+        "sp": 0
+      },
+      "nature": "Bold",
+      "ability": "Intimidate",
+      "item": "Leftovers",
+      "moves": [
+        "",
+        "Volt Switch",
+        "",
+        ""
+      ]
+    }
+  },
+  "Clefable": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 156,
+        "sa": 28,
+        "sd": 68,
+        "sp": 4
+      },
+      "nature": "Bold",
+      "ability": "Unaware",
+      "item": "Sitrus Berry",
+      "moves": [
+        "",
+        "",
+        "Moonblast",
+        ""
+      ]
+    }
+  },
+  "Sigilyph": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 156,
+        "sa": 0,
+        "sd": 96,
+        "sp": 0
+      },
+      "nature": "Calm",
+      "ability": "Magic Guard",
+      "item": "Life Orb",
+      "moves": [
+        "Stored Power",
+        "",
+        "",
+        "Psychic"
+      ]
+    }
+  },
+  "Jellicent": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 4,
+        "sa": 252,
+        "sd": 0,
+        "sp": 0
+      },
+      "nature": "Quiet",
+      "ability": "Water Absorb",
+      "item": "Sitrus Berry",
+      "moves": [
+        "",
+        "Water Spout",
+        "",
+        "Shadow Ball"
+      ]
+    }
+  },
+  "Shiftry": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Adamant",
+      "ability": "Chlorophyll",
+      "item": "Life Orb",
+      "moves": [
+        "Knock Off",
+        "Leaf Blade",
+        "",
+        ""
+      ]
+    }
+  },
+  "Qwilfish": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 196,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 60
+      },
+      "nature": "Adamant",
+      "ability": "Intimidate",
+      "item": "Expert Belt",
+      "moves": [
+        "Poison Jab",
+        "Aqua Jet",
+        "Waterfall",
+        ""
+      ]
+    }
+  },
+  "Mienshao": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "Fake Out",
+        "",
+        "Rock Slide",
+        "Low Kick"
+      ]
+    }
+  },
+  "Cryogonal": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 0,
+        "de": 0,
+        "sa": 36,
+        "sd": 220,
+        "sp": 0
+      },
+      "nature": "Timid",
+      "ability": "Levitate",
+      "item": "Expert Belt",
+      "moves": [
+        "Freeze-Dry",
+        "Flash Cannon",
+        "",
+        "Ice Beam"
+      ]
+    }
+  },
+  "Latios": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "Levitate",
+      "item": "Life Orb",
+      "moves": [
+        "Draco Meteor",
+        "Psyshock",
+        "",
+        "Psychic"
+      ]
+    }
+  },
+  "Ludicolo": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 84,
+        "sa": 148,
+        "sd": 4,
+        "sp": 20
+      },
+      "nature": "Modest",
+      "ability": "Swift Swim",
+      "item": "Assault Vest",
+      "moves": [
+        "Fake Out",
+        "Giga Drain",
+        "Ice Beam",
+        "Scald"
+      ]
+    }
+  },
+  "Claydol": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 4,
+        "de": 4,
+        "sa": 0,
+        "sd": 248,
+        "sp": 0
+      },
+      "nature": "Sassy",
+      "ability": "Levitate",
+      "item": "Leftovers",
+      "moves": [
+        "",
+        "",
+        "Explosion",
+        "Psyshock"
+      ]
+    }
+  },
+  "Clawitzer": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 188,
+        "at": 0,
+        "de": 92,
+        "sa": 228,
+        "sd": 0,
+        "sp": 0
+      },
+      "nature": "Quiet",
+      "ability": "Mega Launcher",
+      "item": "Life Orb",
+      "moves": [
+        "Aura Sphere",
+        "Dark Pulse",
+        "Water Pulse",
+        ""
+      ]
+    }
+  },
+  "Gogoat": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 220,
+        "at": 68,
+        "de": 220,
+        "sa": 0,
+        "sd": 0,
+        "sp": 0
+      },
+      "nature": "Impish",
+      "ability": "Sap Sipper",
+      "item": "",
+      "moves": [
+        "Horn Leech",
+        "",
+        "Earthquake",
+        ""
+      ]
+    }
+  },
+  "Flygon": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "Levitate",
+      "item": "Choice Scarf",
+      "moves": [
+        "Earthquake",
+        "U-turn",
+        "Dragon Claw",
+        "Rock Slide"
+      ]
+    }
+  },
+  "Rotom-Heat": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 84,
+        "sa": 4,
+        "sd": 4,
+        "sp": 164
+      },
+      "nature": "Bold",
+      "ability": "Levitate",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Overheat",
+        "Thunderbolt",
+        "",
+        ""
+      ]
+    }
+  },
+  "Escavalier": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 4,
+        "sp": 0
+      },
+      "nature": "Brave",
+      "ability": "Overcoat",
+      "item": "Choice Band",
+      "moves": [
+        "Iron Head",
+        "Megahorn",
+        "Drill Run",
+        "Knock Off"
+      ]
+    }
+  },
+  "Malamar": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 148,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 108,
+        "sp": 0
+      },
+      "nature": "Adamant",
+      "ability": "Contrary",
+      "item": "Assault Vest",
+      "moves": [
+        "Superpower",
+        "Psycho Cut",
+        "Knock Off",
+        ""
+      ]
+    }
+  },
+  "Cherrim": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 252,
+        "sa": 0,
+        "sd": 4,
+        "sp": 0
+      },
+      "nature": "Bold",
+      "ability": "Flower Gift",
+      "item": "Sitrus Berry",
+      "moves": [
+        "",
+        "",
+        "Solar Beam",
+        ""
+      ]
+    }
+  },
+  "Entei": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 68,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 188
+      },
+      "nature": "Jolly",
+      "ability": "",
+      "item": "Leftovers",
+      "moves": [
+        "Sacred Fire",
+        "",
+        "",
+        "Snarl"
+      ]
+    }
+  },
+  "Steelix": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 4,
+        "sp": 0
+      },
+      "nature": "Brave",
+      "ability": "",
+      "item": "Steelixite",
+      "moves": [
+        "Earthquake",
+        "",
+        "Rock Slide",
+        "Heavy Slam"
+      ]
+    }
+  },
+  "Regice": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 156,
+        "at": 0,
+        "de": 252,
+        "sa": 100,
+        "sd": 0,
+        "sp": 0
+      },
+      "nature": "Bold",
+      "ability": "Clear Body",
+      "item": "Assault Vest",
+      "moves": [
+        "Thunderbolt",
+        "Ice Beam",
+        "Icy Wind",
+        ""
+      ]
+    }
+  },
+  "Armaldo": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Adamant",
+      "ability": "Swift Swim",
+      "item": "Life Orb",
+      "moves": [
+        "Rock Slide",
+        "X-Scissor",
+        "",
+        "Aqua Jet"
+      ]
+    }
+  },
+  "Espeon": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "",
+      "item": "Choice Specs",
+      "moves": [
+        "Dazzling Gleam",
+        "Psychic",
+        "Shadow Ball",
+        "Psyshock"
+      ]
+    }
+  },
+  "Bouffalant": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 164,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 92,
+        "sp": 0
+      },
+      "nature": "Adamant",
+      "ability": "Soundproof",
+      "item": "Choice Band",
+      "moves": [
+        "Head Charge",
+        "Superpower",
+        "Stone Edge",
+        "Iron Head"
+      ]
+    }
+  },
+  "Ninetales": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 172,
+        "at": 0,
+        "de": 60,
+        "sa": 212,
+        "sd": 12,
+        "sp": 52
+      },
+      "nature": "Modest",
+      "ability": "Drought",
+      "item": "Leftovers",
+      "moves": [
+        "",
+        "Heat Wave",
+        "Solar Beam",
+        ""
+      ]
+    }
+  },
+  "Landorus": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "Sand Force",
+      "item": "Life Orb",
+      "moves": [
+        "Earth Power",
+        "Sludge Bomb",
+        "",
+        "Hidden Power Ice"
+      ]
+    }
+  },
+  "Azumarill": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 228,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 28
+      },
+      "nature": "Adamant",
+      "ability": "Huge Power",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Aqua Jet",
+        "Play Rough",
+        "",
+        ""
+      ]
+    }
+  },
+  "Muk": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 200,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 56,
+        "sp": 0
+      },
+      "nature": "Adamant",
+      "ability": "",
+      "item": "Black Sludge",
+      "moves": [
+        "",
+        "Gunk Shot",
+        "Poison Jab",
+        "Fire Punch"
+      ]
+    }
+  },
+  "Clefairy": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 108,
+        "at": 0,
+        "de": 252,
+        "sa": 12,
+        "sd": 132,
+        "sp": 4
+      },
+      "nature": "Calm",
+      "ability": "",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "",
+        "Moonblast",
+        ""
+      ]
+    }
+  },
+  "Murkrow": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 252,
+        "sa": 4,
+        "sd": 0,
+        "sp": 0
+      },
+      "nature": "Bold",
+      "ability": "",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Camerupt": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 4,
+        "sa": 252,
+        "sd": 0,
+        "sp": 0
+      },
+      "nature": "Quiet",
+      "ability": "Solid Rock",
+      "item": "Cameruptite",
+      "moves": [
+        "Earth Power",
+        "",
+        "Heat Wave",
+        "Ancient Power"
+      ]
+    }
+  },
+  "Dusclops": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 164,
+        "sa": 0,
+        "sd": 92,
+        "sp": 0
+      },
+      "nature": "Sassy",
+      "ability": "",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "",
+        "",
+        "Night Shade"
+      ]
+    }
+  },
+  "Hydreigon": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Modest",
+      "ability": "Levitate",
+      "item": "Choice Specs",
+      "moves": [
+        "Dark Pulse",
+        "Draco Meteor",
+        "Earth Power",
+        "Fire Blast"
+      ]
+    }
+  },
+  "Mr. Mime": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 240,
+        "at": 0,
+        "de": 44,
+        "sa": 0,
+        "sd": 4,
+        "sp": 220
+      },
+      "nature": "Timid",
+      "ability": "Filter",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Icy Wind",
+        "",
+        "Foul Play",
+        ""
+      ]
+    }
+  },
+  "Meganium": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 0,
+        "de": 156,
+        "sa": 0,
+        "sd": 100,
+        "sp": 0
+      },
+      "nature": "Calm",
+      "ability": "Overgrow",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "Giga Drain",
+        ""
+      ]
+    }
+  },
+  "Shedinja": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 252,
+        "de": 4,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Adamant",
+      "ability": "Wonder Guard",
+      "item": "",
+      "moves": [
+        "Shadow Sneak",
+        "X-Scissor",
+        "",
+        ""
+      ]
+    }
+  },
+  "Carracosta": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 252,
+        "de": 4,
+        "sa": 0,
+        "sd": 0,
+        "sp": 0
+      },
+      "nature": "Brave",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "Aqua Jet",
+        "",
+        "Stone Edge",
+        "Aqua Tail"
+      ]
+    }
+  },
+  "Azelf": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 68,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 0,
+        "sp": 188
+      },
+      "nature": "Modest",
+      "ability": "Levitate",
+      "item": "Choice Scarf",
+      "moves": [
+        "Fire Blast",
+        "Energy Ball",
+        "Psyshock",
+        "Hidden Power Ice"
+      ]
+    }
+  },
+  "Gallade": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 252,
+        "de": 0,
+        "sa": 0,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Jolly",
+      "ability": "",
+      "item": "Galladite",
+      "moves": [
+        "Close Combat",
+        "",
+        "Ice Punch",
+        ""
+      ]
+    }
+  },
+  "Skarmory": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 248,
+        "at": 0,
+        "de": 164,
+        "sa": 0,
+        "sd": 96,
+        "sp": 0
+      },
+      "nature": "Impish",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "Brave Bird",
+        "",
+        ""
+      ]
+    }
+  },
+  "Yanmega": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 0,
+        "at": 0,
+        "de": 0,
+        "sa": 252,
+        "sd": 0,
+        "sp": 252
+      },
+      "nature": "Timid",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "Hidden Power Ice",
+        "",
+        "",
+        "Bug Buzz"
+      ]
+    }
+  },
+  "Miltank": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 204,
+        "at": 0,
+        "de": 44,
+        "sa": 4,
+        "sd": 220,
+        "sp": 36
+      },
+      "nature": "Calm",
+      "ability": "Thick Fat",
+      "item": "Leftovers",
+      "moves": [
+        "",
+        "",
+        "",
+        "Seismic Toss"
+      ]
+    }
+  },
+  "Hitmontop": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 252,
+        "at": 164,
+        "de": 4,
+        "sa": 0,
+        "sd": 76,
+        "sp": 12
+      },
+      "nature": "Careful",
+      "ability": "Intimidate",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Fake Out",
+        "Close Combat",
+        "",
+        ""
+      ]
+    }
+  },
+  "Volbeat": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 248,
+        "at": 0,
+        "de": 244,
+        "sa": 0,
+        "sd": 12,
+        "sp": 0
+      },
+      "nature": "Calm",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Kingdra": {
+    "Smogon VGC Paradigm": {
+      "level": 50,
+      "evs": {
+        "hp": 4,
+        "at": 0,
+        "de": 4,
+        "sa": 244,
+        "sd": 4,
+        "sp": 252
+      },
+      "nature": "Modest",
+      "ability": "Swift Swim",
+      "item": "Life Orb",
+      "moves": [
+        "Draco Meteor",
+        "",
+        "Muddy Water",
+        ""
+      ]
+    }
+  }
+};

--- a/setdex_xy.js
+++ b/setdex_xy.js
@@ -1,1 +1,26 @@
-var SETDEX_XY={"Abomasnow":{"Placeholder":{"level":50,"evs":{"sa":252,"hp":8,"sp":84,"at":160,"sd":4},"nature":"Lonely","ability":"Soundproof","item":"Abomasite","moves":["Ice Shard","Wood Hammer","Blizzard","Earthquake"]}}};
+var SETDEX_XY={};
+(function () {
+	var old = {
+		"Abomasnow": {
+			"Placeholder": {
+				"level":50,
+				"evs": {
+					"sa":252,
+					"hp":8,
+					"sp":84,
+					"at":160,
+					"sd":4
+				},
+				"nature":"Lonely",
+				"ability":"Soundproof",
+				"item":"Abomasite",
+				"moves": [
+					"Ice Shard",
+					"Wood Hammer",
+					"Blizzard",
+					"Earthquake"
+				]
+			}
+		}
+	};
+});


### PR DESCRIPTION
- Added a package.json file (to enable the next step:)
- Added a Gruntfile
  - Default task now retrieves the raw Smogon data and creates "setdex_smogvgc.js"
  - Feature request: Clean up the gruntfile, extract the bits of the task into their own file
  - Feature request: Find a way to get the best-possible VGC data by crawling the smogon site
- Cleaned out almost everything from the various setdex files
- Added setdex_smogvgc to index.html and removed setdex_xy
- Added a gitignore file since there's now artifacts that shouldn't be checked in, like the node_modules dir

To use the new stuff:
- Install node.js from nodejs.org.  I'm using 0.10, but it looks like 0.12 just was released; haven't tested with 0.12
- Run "sudo npm install -g grunt-cli" from anywhere
- From inside the root project dir, run "npm install"
- Run "grunt" to download the Smogon datafile, parse it, and create setdex_smogvgc.js

It occurs to me now that (while I generally avoid checking in generated files at all costs) we'll need to add the
setdex_smogvgc.js file to the repo, simply so that the GH auto-publish will function.
