### PR TITLE
No more "smogvgc", some other cleanup

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -85,24 +85,27 @@ module.exports = function (grunt) {
             //         return leven(inKey, a) - leven(inKey, b);
             //     })[0];
 
-            var bestMatch = {
-                val: 'NOMATCH',
-                dist: Number.MAX_VALUE
-            }
-
-            function mangle(s) {
-                return s.replace(/\W/g, '').toLowerCase();
-            }
-
-            ary.forEach(function (a) {
-                var dist = leven(inKey, mangle(a));
-                if (dist < bestMatch.dist) {
-                    bestMatch.val = a;
-                    bestMatch.dist = dist;
+            if (inKey) {
+                var bestMatch = {
+                    val: 'NOMATCH',
+                    dist: Number.MAX_VALUE
                 }
-            });
-            if (bestMatch.dist < 3) {
-                return bestMatch.val;
+
+                function mangle(s) {
+                    return s.replace(/\W/g, '').toLowerCase();
+                }
+
+                var mangledKey = mangle(inKey);
+                ary.forEach(function (a) {
+                    var dist = leven(mangledKey, mangle(a));
+                    if (dist < bestMatch.dist) {
+                        bestMatch.val = a;
+                        bestMatch.dist = dist;
+                    }
+                });
+                if (bestMatch.dist < 3) {
+                    return bestMatch.val;
+                }
             }
             // There weren't any sufficiently close matches, which happens a lot for (eg) status moves
             return '';
@@ -168,5 +171,5 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-http');
 
     grunt.registerTask('default', ['showdown']);
-    grunt.registerTask('all', ['http', 'showdown', 'globalLink']);
+    grunt.registerTask('all', ['http', 'globalLinkDownload', 'showdown', 'globalLink']);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -213,7 +213,7 @@ module.exports = function (grunt) {
             grunt.log.ok('Reading data file ' + fn);
             data = require('./' + fn);
         } catch (e) { 
-            grunt.log.error('Failed to require the data file: ' + fn);
+            grunt.fail.fatal('Failed to require the data file: ' + fn);
         }
         
         grunt.log.write('Processing sets');

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,10 +4,10 @@ module.exports = function (grunt) {
     // their own namespace. Global Namespace Pollution BAAAD!
     var LevenWork = (function (grunt) {
 
-        var MOVES_FILE     = './move_data.js';
-        var ABILITIES_FILE = './ability_data.js';
-        var NATURES_FILE   = './nature_data.js';
-        var ITEMS_FILE     = './item_data.js';
+        var MOVES_FILE     = process.cwd() + '/move_data.js';
+        var ABILITIES_FILE = process.cwd() + '/ability_data.js';
+        var NATURES_FILE   = process.cwd() + '/nature_data.js';
+        var ITEMS_FILE     = process.cwd() + '/item_data.js';
 
         var leven = require('levenshtein');
         var $ = {
@@ -16,10 +16,10 @@ module.exports = function (grunt) {
 
         var moves, abilities, natures, items;
 
-        eval(grunt.file.read(MOVES_FILE, 'utf8'));
-        eval(grunt.file.read(ABILITIES_FILE, 'utf8'));
-        eval(grunt.file.read(NATURES_FILE, 'utf8'));
-        eval(grunt.file.read(ITEMS_FILE, 'utf8'));
+        eval(grunt.file.read(MOVES_FILE));
+        eval(grunt.file.read(ABILITIES_FILE));
+        eval(grunt.file.read(NATURES_FILE));
+        eval(grunt.file.read(ITEMS_FILE));
 
         var moves     = Object.keys(MOVES_XY);
         var abilities = ABILITIES_XY;
@@ -116,13 +116,16 @@ module.exports = function (grunt) {
         }
     })(grunt);
 
+    // HAAAACK
+    grunt.LevenWork = LevenWork;
+
     grunt.initConfig({
         http: {
             showdown: {
                 options: {
                     url: 'http://www.smogon.com/stats/2015-01/chaos/<%= showdown.rawFile %>'
                 },
-                dest: '<%= showdown.rawFile %>'
+                dest: process.cwd() + '<%= showdown.rawFile %>'
             }
         },
         showdown: {
@@ -130,113 +133,40 @@ module.exports = function (grunt) {
             genFile: 'setdex_showdown.js'
 
         },
+        globalLinkDownload: {
+            rawDir: '<%= globalLink.rawDir %>',
+            request: {
+                url: 'http://3ds.pokemon-gl.com/frontendApi/gbu/getSeasonPokemonDetail',
+                headers: {
+                    Referer: 'http://3ds.pokemon-gl.com/battle/oras/'
+                },
+                initialParams: {
+                    languageId: 2,
+                    seasonId: 108,
+                    battleType: 2,
+                    timezone: 'EST',
+                    pokemonId: '1-0',
+                    displayNumberWaza: 10,
+                    displayNumberTokusei: 3,
+                    displayNumberSeikaku: 10,
+                    displayNumberItem: 10,
+                    displayNumberLevel: 10,
+                    displayNumberPokemonIn: 10,
+                    displayNumberPokemonDown: 10,
+                    displayNumberPokemonDownWaza: 10
+                }
+            }
+        },
         globalLink: {
-            rawDir: 'globalLink',
-            genFile: 'setdex_globalLink.js'
+            rawDir: process.cwd() + '/globalLink',
+            genFile: 'setdex_globalLink.js',
         }
     });
 
-    function getSimpleSorted(obj, max) {
-        if (!max) {
-            max = Object.keys(obj).length;
-        }
-
-        return Object.keys(obj).sort(function (a, b) {
-            return obj[b] - obj[a];
-        }).slice(0, max);
-    }
-
-    var spreadPattern = /([A-Za-z]+):(\d+)\/(\d+)\/(\d+)\/(\d+)\/(\d+)\/(\d+)/;
-    function parseSpread(spread) {
-        // JS regexp is SLOW.  Consider doing this with a simple series of splits instead.
-        // Pros: faster.  Cons: less nerd cred. Pros: It's an ugly regexp anyway
-        // Adamant:84/220/12/0/20/172
-        var rv = {
-                nature: 'Hardy',
-                evs: {
-                    hp: 0,
-                    at: 0,
-                    df: 0,
-                    sa: 0,
-                    sd: 0,
-                    sp: 0
-                }
-            };
-
-        var match = spread.match(spreadPattern);
-        if (match) {
-            rv = {
-                nature: match[1],
-                evs: {
-                    hp: parseInt(match[2]),
-                    at: parseInt(match[3]),
-                    df: parseInt(match[4]),
-                    sa: parseInt(match[5]),
-                    sd: parseInt(match[6]),
-                    sp: parseInt(match[7])
-                }
-            };
-        }
-        return rv;
-
-    }
-
-    function individualSet(pokeData) {
-        var spreadRaw = getSimpleSorted(pokeData.Spreads, 1)[0];
-        var spread = parseSpread(spreadRaw);
-
-        return { 
-            "Common Showdown": {
-                level:   50,
-                evs:     spread.evs,
-                nature:  LevenWork.closestNature(spread.nature),
-                ability: LevenWork.closestAbility(getSimpleSorted(pokeData.Abilities, 1)[0]),
-                item:    LevenWork.closestItem(getSimpleSorted(pokeData.Items, 1)[0]),
-                moves:   getSimpleSorted(pokeData.Moves, 4).map(function (a) { return LevenWork.closestMove(a); })
-            }
-        };
-    }
-
-    function findSets(fn) {
-        // This is the cheesy way to read valid JSON.
-        var data = {};
-        var sets = {};
-        try {
-            grunt.log.ok('Reading data file ' + fn);
-            data = require('./' + fn);
-        } catch (e) { 
-            grunt.fail.fatal('Failed to require the data file: ' + fn);
-        }
-        
-        grunt.log.write('Processing sets');
-        for (var p in data.data) {
-            if (data.data.hasOwnProperty(p)) {
-                // p is the name of a Pokemon; the data's in data.data[p] (eg data["data"]["Abomasnow"])
-                grunt.log.write('.');
-                sets[p] = individualSet(data.data[p]);
-            }
-        }
-        grunt.log.ok();
-
-        return sets;
-    }
-
-    function generateShowdownDex(raw, out) {
-        var sets = findSets(raw);
-        var outText = 'var SETDEX_SHOWDOWN=' + JSON.stringify(sets, null, 2) +';';
-        grunt.log.ok('Writing output to ' + out);
-        grunt.file.write(out, outText);
-    }
+    grunt.loadTasks('grunt');
 
     grunt.loadNpmTasks('grunt-http');
 
-    grunt.registerTask('showdown', 'Generate Showdown Dex', function () {
-        generateShowdownDex(grunt.config([this.name, 'rawFile']), grunt.config([this.name, 'genFile']));
-    });
-    
-    grunt.registerTask('globallink', 'Generate Global Link data', function () { 
-        generateGlobalLinkDex(rawFile.globalLink, genFile.globalLink); 
-    });
-
     grunt.registerTask('default', ['showdown']);
+    grunt.registerTask('all', ['http', 'showdown', 'globalLink']);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,3 @@
-var rawFile = 'vgc2015-1500.json';
-var genFile = 'setdex_smogvgc.js';
-
 module.exports = function (grunt) {
 
     // Since I want to avoid polluting the global namespace, we're going to eval all the datafiles in
@@ -119,30 +116,25 @@ module.exports = function (grunt) {
         }
     })(grunt);
 
-
     grunt.initConfig({
         http: {
-            smogon: {
+            showdown: {
                 options: {
-                    url: 'http://www.smogon.com/stats/2015-01/chaos/' + rawFile
+                    url: 'http://www.smogon.com/stats/2015-01/chaos/<%= showdown.rawFile %>'
                 },
-                dest: rawFile
+                dest: '<%= showdown.rawFile %>'
             }
+        },
+        showdown: {
+            rawFile: 'vgc2015-1500.json',
+            genFile: 'setdex_showdown.js'
+
+        },
+        globalLink: {
+            rawDir: 'globalLink',
+            genFile: 'setdex_globalLink.js'
         }
     });
-
-    function needsDownload(fn) {
-        return !grunt.file.exists(fn);
-    }
-
-    function optionalHttp() {
-        if (needsDownload(rawFile)) {
-            grunt.log.ok('File doesn\'t exist, downloading: ' + rawFile);
-            grunt.task.run('http');
-        } else {
-            grunt.log.ok('File exists, not downloading: ' + rawFile);
-        }
-    }
 
     function getSimpleSorted(obj, max) {
         if (!max) {
@@ -229,15 +221,22 @@ module.exports = function (grunt) {
         return sets;
     }
 
-    function generateSetdex(raw, out) {
-        optionalHttp();
+    function generateShowdownDex(raw, out) {
         var sets = findSets(raw);
-        var outText = 'var SETDEX_XY=' + JSON.stringify(sets, null, 2) +';';
-        grunt.log.ok('Writing output to ' + genFile);
-        grunt.file.write(genFile, outText);
+        var outText = 'var SETDEX_SHOWDOWN=' + JSON.stringify(sets, null, 2) +';';
+        grunt.log.ok('Writing output to ' + out);
+        grunt.file.write(out, outText);
     }
 
     grunt.loadNpmTasks('grunt-http');
 
-    grunt.registerTask('default', 'Download if necessary', function () { generateSetdex(rawFile, genFile); });
+    grunt.registerTask('showdown', 'Generate Showdown Dex', function () {
+        generateShowdownDex(grunt.config([this.name, 'rawFile']), grunt.config([this.name, 'genFile']));
+    });
+    
+    grunt.registerTask('globallink', 'Generate Global Link data', function () { 
+        generateGlobalLinkDex(rawFile.globalLink, genFile.globalLink); 
+    });
+
+    grunt.registerTask('default', ['showdown']);
 };

--- a/grunt/globalLink.js
+++ b/grunt/globalLink.js
@@ -1,3 +1,4 @@
+var extend = require('jquery-extend');
 var request = require('request');
 
 module.exports = function (grunt) {
@@ -41,11 +42,93 @@ module.exports = function (grunt) {
         downloadOnePokemon(requestParams, keepGoing);
     }
 
+    function getFormeName(info) {
+        if (info.name === 'Rotom') {
+            switch (info.typeName2) {
+                case 'Ghost':
+                    return 'Rotom';
+                case 'Grass':
+                    return 'Rotom-C';
+                case 'Ice':
+                    return 'Rotom-F';
+                case 'Fire':
+                    return 'Rotom-H';
+                case 'Flying':
+                    return 'Rotom-S';
+                case 'Water':
+                    return 'Rotom-W';
+            }
+        } else if (info.name === 'Landorus' ||
+                   info.name === 'Tornadus' ||
+                   info.name === 'Thundurus') {
+            if (info.formNo === '1') {
+                return info.name + '-T';
+            }
+        } else if (info.name === 'Pumpkaboo' ||
+                   info.name === 'Gourgeist') {
+            switch (info.formNo) {
+                case '0':
+                    return info.name + '-Average';
+                case '1':
+                    return info.name + '-Small';
+                case '2':
+                    return info.name + '-Large';
+                case '3':
+                    return info.name + '-Super';
+
+            }
+        }
+        return info.name;
+    }
+
+    function individualSet(data) {
+        var rv = {};
+        // We need the "info" for the name (and possibly types), and "trend" for the rest of the data
+        if (data && data.rankingPokemonInfo && data.rankingPokemonTrend) {
+            try {
+                // Note: This assumes all info arrays are properly ranked.  If that ever changes, this'll
+                // need to actually sort the arrays (or at least look for ranking === 1)
+                var trend   = data.rankingPokemonTrend;
+                var nature  = trend.seikakuInfo && trend.seikakuInfo[0].name;
+                var ability = trend.tokuseiInfo && trend.tokuseiInfo[0].name;
+                var item    = trend.itemInfo && trend.itemInfo[0].name;
+                var moves   = trend.wazaInfo && trend.wazaInfo.slice(0,4).map(function (a) { return a.name; });
+                var name    = getFormeName(data.rankingPokemonInfo);
+
+                rv[name] = {
+                    "Common Battle Spot": {
+                        level:   50,
+                        evs:     {},
+                        nature:  grunt.LevenWork.closestNature(nature),
+                        ability: grunt.LevenWork.closestAbility(ability),
+                        item:    grunt.LevenWork.closestItem(item),
+                        moves:   moves.map(function (a) { return grunt.LevenWork.closestMove(a); })
+                    }
+                };
+            } catch (e) {
+                grunt.fail.warn('Error extracting set info for ' + data.rankingPokemonInfo.name + ': ' + e);
+            }
+        }
+        return rv;
+    }
+
+    function generateGlobalLinkDex(inDir, out) {
+        var sets = {};
+        grunt.log.write('Processing sets');
+        grunt.file.recurse(inDir, function (abspath) {
+            sets = extend(sets, individualSet(grunt.file.readJSON(abspath)));
+            grunt.log.write('.');
+        });
+        grunt.log.ok();
+
+        var outText = 'var SETDEX_GLOBALLINK=' + JSON.stringify(sets, null, 2) +';';
+        var trueOutf = process.cwd() + '/' + out;
+        grunt.log.ok('Writing output to ' + trueOutf);
+        grunt.file.write(trueOutf, outText);
+
+    }
+
     grunt.registerTask('globalLinkDownload', 'Download the Global Link data', function () {
-        // downloadGlobalLinkData({
-        //     grunt.config([this.name, 'rawDir']),
-        //     grunt.config([this.name, 'request'])
-        // });
         var done = this.async();
         downloadAllPokemon(
             grunt.config([this.name, 'rawDir']), 
@@ -56,7 +139,7 @@ module.exports = function (grunt) {
         );
     });
 
-    grunt.registerTask('globallink', 'Generate Global Link dex data', function () { 
+    grunt.registerTask('globalLink', 'Generate Global Link dex data', function () { 
         generateGlobalLinkDex(
             grunt.config([this.name, 'rawDir']), 
             grunt.config([this.name, 'genFile'])

--- a/grunt/globalLink.js
+++ b/grunt/globalLink.js
@@ -1,0 +1,65 @@
+var request = require('request');
+
+module.exports = function (grunt) {
+    
+    function downloadOnePokemon(requestParams, cb) {
+        var outFile = requestParams.outFile();
+        grunt.log.ok('Downloading to ' + outFile);
+        
+        request.post({
+            url: requestParams.url,
+            method: 'POST',
+            headers: requestParams.headers,
+            form: requestParams.params
+        }, function (err, res, body) {
+            if (!err) {
+                grunt.file.write(outFile, body);
+                var json = JSON.parse(body);
+                cb(true, json.nextPokemonId);
+            } else {
+                grunt.fail.warn('Error retrieving data from Global Link: ' + err);
+                cb(false, '1-0');
+            }
+        });
+    }
+
+    function downloadAllPokemon(rawDir, requestParams, cb) {
+        requestParams.params = requestParams.initialParams;
+        requestParams.outFile = function () {
+            return rawDir + '/' + requestParams.params.pokemonId + '.json'
+        };
+
+        function keepGoing (res, nextId) {
+            if (nextId === '1-0') {
+                cb(res);
+            } else {
+                requestParams.params.pokemonId = nextId;
+                downloadOnePokemon(requestParams, keepGoing);
+            }            
+        }
+
+        downloadOnePokemon(requestParams, keepGoing);
+    }
+
+    grunt.registerTask('globalLinkDownload', 'Download the Global Link data', function () {
+        // downloadGlobalLinkData({
+        //     grunt.config([this.name, 'rawDir']),
+        //     grunt.config([this.name, 'request'])
+        // });
+        var done = this.async();
+        downloadAllPokemon(
+            grunt.config([this.name, 'rawDir']), 
+            grunt.config([this.name, 'request']), 
+            function (res) {
+                done(res);
+            }
+        );
+    });
+
+    grunt.registerTask('globallink', 'Generate Global Link dex data', function () { 
+        generateGlobalLinkDex(
+            grunt.config([this.name, 'rawDir']), 
+            grunt.config([this.name, 'genFile'])
+        );
+    });
+};

--- a/grunt/showdown.js
+++ b/grunt/showdown.js
@@ -61,6 +61,29 @@ module.exports = function (grunt) {
         };
     }
 
+    function getFormeName(name) {
+        switch (name) {
+            case 'Rotom-Frost':
+                return 'Rotom-F';
+            case 'Rotom-Fan':
+                return 'Rotom-S';
+            case 'Rotom-Heat':
+                return 'Rotom-H';
+            case 'Rotom-Wash':
+                return 'Rotom-W';
+            case 'Rotom-Mow':
+                return 'Rotom-C';
+            
+            case 'Landorus-Therian':
+                return 'Landorus-T';
+            case 'Tornadus-Therian':
+                return 'Tornadus-T';
+            case 'Thundurus-Therian':
+                return 'Thundurus-T';
+        }
+        return name;
+    }
+
     function findSets(fn) {
         // This is the cheesy way to read valid JSON.
         var data = {};
@@ -77,7 +100,8 @@ module.exports = function (grunt) {
             if (data.data.hasOwnProperty(p)) {
                 // p is the name of a Pokemon; the data's in data.data[p] (eg data["data"]["Abomasnow"])
                 grunt.log.write('.');
-                sets[p] = individualSet(data.data[p]);
+                var formeName = getFormeName(p);
+                sets[formeName] = individualSet(data.data[p]);
             }
         }
         grunt.log.ok();

--- a/grunt/showdown.js
+++ b/grunt/showdown.js
@@ -1,0 +1,100 @@
+module.exports = function (grunt) {
+
+    function getSimpleSorted(obj, max) {
+        if (!max) {
+            max = Object.keys(obj).length;
+        }
+
+        return Object.keys(obj).sort(function (a, b) {
+            return obj[b] - obj[a];
+        }).slice(0, max);
+    }
+
+    var spreadPattern = /([A-Za-z]+):(\d+)\/(\d+)\/(\d+)\/(\d+)\/(\d+)\/(\d+)/;
+    function parseSpread(spread) {
+        // JS regexp is SLOW.  Consider doing this with a simple series of splits instead.
+        // Pros: faster.  Cons: less nerd cred. Pros: It's an ugly regexp anyway
+        // Adamant:84/220/12/0/20/172
+        var rv = {
+                nature: 'Hardy',
+                evs: {
+                    hp: 0,
+                    at: 0,
+                    df: 0,
+                    sa: 0,
+                    sd: 0,
+                    sp: 0
+                }
+            };
+
+        var match = spread.match(spreadPattern);
+        if (match) {
+            rv = {
+                nature: match[1],
+                evs: {
+                    hp: parseInt(match[2]),
+                    at: parseInt(match[3]),
+                    df: parseInt(match[4]),
+                    sa: parseInt(match[5]),
+                    sd: parseInt(match[6]),
+                    sp: parseInt(match[7])
+                }
+            };
+        }
+        return rv;
+
+    }
+
+    function individualSet(pokeData) {
+        var spreadRaw = getSimpleSorted(pokeData.Spreads, 1)[0];
+        var spread = parseSpread(spreadRaw);
+
+        return { 
+            "Common Showdown": {
+                level:   50,
+                evs:     spread.evs,
+                nature:  grunt.LevenWork.closestNature(spread.nature),
+                ability: grunt.LevenWork.closestAbility(getSimpleSorted(pokeData.Abilities, 1)[0]),
+                item:    grunt.LevenWork.closestItem(getSimpleSorted(pokeData.Items, 1)[0]),
+                moves:   getSimpleSorted(pokeData.Moves, 4).map(function (a) { return grunt.LevenWork.closestMove(a); })
+            }
+        };
+    }
+
+    function findSets(fn) {
+        // This is the cheesy way to read valid JSON.
+        var data = {};
+        var sets = {};
+        try {
+            grunt.log.ok('Reading data file ' + fn);
+            data = require(process.cwd() + '/' + fn);
+        } catch (e) { 
+            grunt.fail.fatal('Failed to require the data file: ' + fn);
+        }
+        
+        grunt.log.write('Processing sets');
+        for (var p in data.data) {
+            if (data.data.hasOwnProperty(p)) {
+                // p is the name of a Pokemon; the data's in data.data[p] (eg data["data"]["Abomasnow"])
+                grunt.log.write('.');
+                sets[p] = individualSet(data.data[p]);
+            }
+        }
+        grunt.log.ok();
+
+        return sets;
+    }
+
+    function generateShowdownDex(raw, out) {
+        var sets = findSets(raw);
+        var outText = 'var SETDEX_SHOWDOWN=' + JSON.stringify(sets, null, 2) +';';
+        var trueOutf = process.cwd() + '/' + out;
+        grunt.log.ok('Writing output to ' + trueOutf);
+        grunt.file.write(trueOutf, outText);
+    }
+    
+    grunt.registerTask('showdown', 'Generate Showdown Dex', function () {
+        generateShowdownDex(grunt.config([this.name, 'rawFile']), grunt.config([this.name, 'genFile']));
+    });
+
+};

--- a/index.html
+++ b/index.html
@@ -321,7 +321,8 @@
     <script type="text/javascript" src="https://code.jquery.com/jquery-2.1.0.min.js"></script>
     <script type="text/javascript" src="./select2/select2.min.js"></script>
     <script type="text/javascript" src="./pokedex.js"></script>
-    <script type="text/javascript" src="./setdex_smogvgc.js"></script>
+    <script type="text/javascript" src="./setdex_showdown.js"></script>
+    <script type="text/javascript" src="./setdex_xy.js"></script>
     <script type="text/javascript" src="./setdex_bw.js"></script>
     <script type="text/javascript" src="./setdex_dpp.js"></script>
     <script type="text/javascript" src="./setdex_rse.js"></script>

--- a/index.html
+++ b/index.html
@@ -322,6 +322,7 @@
     <script type="text/javascript" src="./select2/select2.min.js"></script>
     <script type="text/javascript" src="./pokedex.js"></script>
     <script type="text/javascript" src="./setdex_showdown.js"></script>
+    <script type="text/javascript" src="./setdex_globalLink.js"></script>
     <script type="text/javascript" src="./setdex_xy.js"></script>
     <script type="text/javascript" src="./setdex_bw.js"></script>
     <script type="text/javascript" src="./setdex_dpp.js"></script>

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "grunt-http": "^1.5.0",
     "jquery-extend": "^2.0.3",
     "levenshtein": "^1.0.5",
-    "load-grunt-config": "^0.16.0",
     "request": "^2.53.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "grunt-http": "^1.5.0",
     "jquery-extend": "^2.0.3",
     "levenshtein": "^1.0.5",
-    "load-grunt-config": "^0.16.0"
+    "load-grunt-config": "^0.16.0",
+    "request": "^2.53.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "grunt-contrib-uglify": "~0.5.0",
     "grunt-http": "^1.5.0",
     "jquery-extend": "^2.0.3",
-    "levenshtein": "^1.0.5"
+    "levenshtein": "^1.0.5",
+    "load-grunt-config": "^0.16.0"
   }
 }

--- a/setdex_globalLink.js
+++ b/setdex_globalLink.js
@@ -1,0 +1,6146 @@
+var SETDEX_GLOBALLINK={
+  "Electrode": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Soundproof",
+      "item": "",
+      "moves": [
+        "Discharge",
+        "",
+        "",
+        "Thunderbolt"
+      ]
+    }
+  },
+  "Exeggutor": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Calm",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Psychic",
+        "",
+        "",
+        "Giga Drain"
+      ]
+    }
+  },
+  "Cubone": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Relaxed",
+      "ability": "Battle Armor",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "",
+        "",
+        "Rock Slide"
+      ]
+    }
+  },
+  "Marowak": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Brave",
+      "ability": "Lightning Rod",
+      "item": "Thick Club",
+      "moves": [
+        "Bonemerang",
+        "Rock Slide",
+        "",
+        "Earthquake"
+      ]
+    }
+  },
+  "Hitmonlee": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "",
+      "item": "Normal Gem",
+      "moves": [
+        "Fake Out",
+        "Close Combat",
+        "",
+        "Rock Slide"
+      ]
+    }
+  },
+  "Hitmonchan": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Iron Fist",
+      "item": "Assault Vest",
+      "moves": [
+        "Fake Out",
+        "Mach Punch",
+        "Ice Punch",
+        "Drain Punch"
+      ]
+    }
+  },
+  "Weezing": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "Levitate",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Sludge Bomb",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Rhydon": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Lightning Rod",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "Earthquake",
+        "Rock Slide",
+        "Ice Punch"
+      ]
+    }
+  },
+  "Chansey": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "",
+      "item": "Eviolite",
+      "moves": [
+        "Seismic Toss",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Tangela": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "",
+        "",
+        "Giga Drain"
+      ]
+    }
+  },
+  "Kangaskhan": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "Scrappy",
+      "item": "Kangaskhanite",
+      "moves": [
+        "Fake Out",
+        "Sucker Punch",
+        "Double-Edge",
+        "Low Kick"
+      ]
+    }
+  },
+  "Goldeen": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Impish",
+      "ability": "Lightning Rod",
+      "item": "Air Balloon",
+      "moves": [
+        "Icy Wind",
+        "",
+        "Waterfall",
+        ""
+      ]
+    }
+  },
+  "Seaking": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "Lightning Rod",
+      "item": "Choice Scarf",
+      "moves": [
+        "Ice Beam",
+        "",
+        "Scald",
+        "Icy Wind"
+      ]
+    }
+  },
+  "Butterfree": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Starmie": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "",
+      "item": "Choice Scarf",
+      "moves": [
+        "Ice Beam",
+        "Hydro Pump",
+        "",
+        ""
+      ]
+    }
+  },
+  "Mr. Mime": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "Filter",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Fake Out",
+        "",
+        "Icy Wind",
+        "Dazzling Gleam"
+      ]
+    }
+  },
+  "Scyther": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "Technician",
+      "item": "Eviolite",
+      "moves": [
+        "Aerial Ace",
+        "",
+        "",
+        "Feint"
+      ]
+    }
+  },
+  "Jynx": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Dry Skin",
+      "item": "",
+      "moves": [
+        "",
+        "Fake Out",
+        "Psyshock",
+        "Blizzard"
+      ]
+    }
+  },
+  "Electabuzz": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "",
+        "Thunderbolt",
+        "Discharge"
+      ]
+    }
+  },
+  "Magmar": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Calm",
+      "ability": "",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "Overheat",
+        "",
+        ""
+      ]
+    }
+  },
+  "Pinsir": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "Hyper Cutter",
+      "item": "Pinsirite",
+      "moves": [
+        "",
+        "Feint",
+        "Return",
+        "Close Combat"
+      ]
+    }
+  },
+  "Tauros": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "",
+      "item": "Lum Berry",
+      "moves": [
+        "Rock Slide",
+        "Earthquake",
+        "",
+        "Return"
+      ]
+    }
+  },
+  "Gyarados": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Intimidate",
+      "item": "Gyaradosite",
+      "moves": [
+        "Waterfall",
+        "",
+        "",
+        "Earthquake"
+      ]
+    }
+  },
+  "Lapras": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Water Absorb",
+      "item": "Assault Vest",
+      "moves": [
+        "Freeze-Dry",
+        "Hydro Pump",
+        "Ice Shard",
+        ""
+      ]
+    }
+  },
+  "Ditto": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        ""
+      ]
+    }
+  },
+  "Eevee": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Vaporeon": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Water Absorb",
+      "item": "Leftovers",
+      "moves": [
+        "Scald",
+        "",
+        "Ice Beam",
+        ""
+      ]
+    }
+  },
+  "Jolteon": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Volt Absorb",
+      "item": "Life Orb",
+      "moves": [
+        "Thunderbolt",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Flareon": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Flash Fire",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Flare Blitz",
+        "Quick Attack",
+        "Superpower",
+        ""
+      ]
+    }
+  },
+  "Porygon": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Download",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "",
+        "Thunderbolt",
+        "Ice Beam"
+      ]
+    }
+  },
+  "Omastar": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Swift Swim",
+      "item": "",
+      "moves": [
+        "Ice Beam",
+        "",
+        "",
+        "Surf"
+      ]
+    }
+  },
+  "Kabutops": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Swift Swim",
+      "item": "Life Orb",
+      "moves": [
+        "Rock Slide",
+        "Aqua Jet",
+        "Waterfall",
+        ""
+      ]
+    }
+  },
+  "Aerodactyl": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "Unnerve",
+      "item": "",
+      "moves": [
+        "Rock Slide",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Snorlax": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Thick Fat",
+      "item": "Choice Band",
+      "moves": [
+        "Return",
+        "Self-Destruct",
+        "Earthquake",
+        "Crunch"
+      ]
+    }
+  },
+  "Articuno": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "",
+      "item": "Assault Vest",
+      "moves": [
+        "Freeze-Dry",
+        "Hurricane",
+        "",
+        "Icy Wind"
+      ]
+    }
+  },
+  "Zapdos": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Thunderbolt",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Moltres": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "",
+      "item": "Charti Berry",
+      "moves": [
+        "Heat Wave",
+        "Air Slash",
+        "",
+        "Hurricane"
+      ]
+    }
+  },
+  "Dragonite": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Multiscale",
+      "item": "",
+      "moves": [
+        "Extreme Speed",
+        "Dragon Claw",
+        "Earthquake",
+        ""
+      ]
+    }
+  },
+  "Beedrill": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "Swarm",
+      "item": "Beedrillite",
+      "moves": [
+        "Poison Jab",
+        "",
+        "U-turn",
+        "Drill Run"
+      ]
+    }
+  },
+  "Meganium": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Calm",
+      "ability": "Overgrow",
+      "item": "Sitrus Berry",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Typhlosion": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Blaze",
+      "item": "Choice Scarf",
+      "moves": [
+        "Eruption",
+        "Focus Blast",
+        "Flamethrower",
+        ""
+      ]
+    }
+  },
+  "Feraligatr": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Torrent",
+      "item": "Leftovers",
+      "moves": [
+        "",
+        "Ice Punch",
+        "Aqua Jet",
+        "Waterfall"
+      ]
+    }
+  },
+  "Furret": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Impish",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "Knock Off",
+        "",
+        ""
+      ]
+    }
+  },
+  "Noctowl": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Calm",
+      "ability": "",
+      "item": "Leftovers",
+      "moves": [
+        "",
+        "",
+        "Night Shade",
+        ""
+      ]
+    }
+  },
+  "Ariados": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Impish",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Crobat": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "",
+      "item": "Lum Berry",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Lanturn": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Volt Absorb",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Thunderbolt",
+        "Ice Beam",
+        "Scald",
+        "Discharge"
+      ]
+    }
+  },
+  "Igglybuff": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Impish",
+      "ability": "",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "",
+        "",
+        "Fling"
+      ]
+    }
+  },
+  "Togetic": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Calm",
+      "ability": "",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Xatu": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "Air Slash",
+        "Heat Wave",
+        "",
+        ""
+      ]
+    }
+  },
+  "Pidgeot": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "",
+      "item": "Pidgeotite",
+      "moves": [
+        "Heat Wave",
+        "Hurricane",
+        "",
+        "Hyper Beam"
+      ]
+    }
+  },
+  "Ampharos": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Quiet",
+      "ability": "",
+      "item": "Ampharosite",
+      "moves": [
+        "Dragon Pulse",
+        "Thunderbolt",
+        "",
+        "Focus Blast"
+      ]
+    }
+  },
+  "Bellossom": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Chlorophyll",
+      "item": "Ganlon Berry",
+      "moves": [
+        "Leaf Blade",
+        "Natural Gift",
+        "",
+        ""
+      ]
+    }
+  },
+  "Azumarill": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Huge Power",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Aqua Jet",
+        "Play Rough",
+        "",
+        ""
+      ]
+    }
+  },
+  "Sudowoodo": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "Sucker Punch",
+        "Rock Slide",
+        "Low Kick",
+        "Ice Punch"
+      ]
+    }
+  },
+  "Politoed": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Drizzle",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Scald",
+        "Ice Beam",
+        "",
+        ""
+      ]
+    }
+  },
+  "Jumpluff": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Infiltrator",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Quagsire": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Impish",
+      "ability": "Unaware",
+      "item": "",
+      "moves": [
+        "",
+        "Earthquake",
+        "Waterfall",
+        ""
+      ]
+    }
+  },
+  "Espeon": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "Psyshock",
+        "",
+        "Psychic",
+        ""
+      ]
+    }
+  },
+  "Umbreon": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "Foul Play",
+        "",
+        "Snarl",
+        ""
+      ]
+    }
+  },
+  "Murkrow": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "",
+        "Foul Play",
+        ""
+      ]
+    }
+  },
+  "Slowking": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Sassy",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "",
+        "Scald",
+        "Psyshock",
+        "Ice Beam"
+      ]
+    }
+  },
+  "Raticate": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Guts",
+      "item": "Flame Orb",
+      "moves": [
+        "Sucker Punch",
+        "",
+        "Facade",
+        "Quick Attack"
+      ]
+    }
+  },
+  "Misdreavus": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "Levitate",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "Icy Wind",
+        "",
+        ""
+      ]
+    }
+  },
+  "Wobbuffet": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "",
+      "item": "Lum Berry",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Girafarig": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Sassy",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "Psychic",
+        "",
+        ""
+      ]
+    }
+  },
+  "Forretress": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Sassy",
+      "ability": "",
+      "item": "Leftovers",
+      "moves": [
+        "Gyro Ball",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Dunsparce": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Impish",
+      "ability": "",
+      "item": "Leftovers",
+      "moves": [
+        "",
+        "Rock Slide",
+        "",
+        ""
+      ]
+    }
+  },
+  "Steelix": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Brave",
+      "ability": "",
+      "item": "Steelixite",
+      "moves": [
+        "Earthquake",
+        "",
+        "Heavy Slam",
+        "Rock Slide"
+      ]
+    }
+  },
+  "Granbull": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Brave",
+      "ability": "Intimidate",
+      "item": "Assault Vest",
+      "moves": [
+        "Play Rough",
+        "Close Combat",
+        "",
+        "Thunder Punch"
+      ]
+    }
+  },
+  "Qwilfish": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Swift Swim",
+      "item": "Black Sludge",
+      "moves": [
+        "Poison Jab",
+        "",
+        "Waterfall",
+        ""
+      ]
+    }
+  },
+  "Scizor": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Technician",
+      "item": "Life Orb",
+      "moves": [
+        "Bullet Punch",
+        "Bug Bite",
+        "",
+        "Knock Off"
+      ]
+    }
+  },
+  "Shuckle": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Heracross": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Guts",
+      "item": "Heracronite",
+      "moves": [
+        "Close Combat",
+        "Pin Missile",
+        "Rock Blast",
+        "Bullet Seed"
+      ]
+    }
+  },
+  "Sneasel": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Hasty",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "Ice Punch",
+        "Icy Wind",
+        ""
+      ]
+    }
+  },
+  "Ursaring": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Brave",
+      "ability": "Guts",
+      "item": "Toxic Orb",
+      "moves": [
+        "Facade",
+        "",
+        "Hammer Arm",
+        "Crunch"
+      ]
+    }
+  },
+  "Slugma": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Hardy",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "Incinerate",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Octillery": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Quiet",
+      "ability": "",
+      "item": "Leftovers",
+      "moves": [
+        "",
+        "Water Spout",
+        "Bite",
+        "Blizzard"
+      ]
+    }
+  },
+  "Delibird": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "",
+      "item": "Choice Scarf",
+      "moves": [
+        "",
+        "Freeze-Dry",
+        "Fake Out",
+        ""
+      ]
+    }
+  },
+  "Mantine": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "Water Absorb",
+      "item": "Leftovers",
+      "moves": [
+        "",
+        "Scald",
+        "Air Slash",
+        ""
+      ]
+    }
+  },
+  "Skarmory": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Impish",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        "Rock Slide"
+      ]
+    }
+  },
+  "Houndoom": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Flash Fire",
+      "item": "Houndoominite",
+      "moves": [
+        "",
+        "Dark Pulse",
+        "Heat Wave",
+        "Solar Beam"
+      ]
+    }
+  },
+  "Kingdra": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Swift Swim",
+      "item": "Life Orb",
+      "moves": [
+        "",
+        "Muddy Water",
+        "Draco Meteor",
+        "Dragon Pulse"
+      ]
+    }
+  },
+  "Donphan": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "",
+      "item": "Lum Berry",
+      "moves": [
+        "Ice Shard",
+        "Earthquake",
+        "Knock Off",
+        "Play Rough"
+      ]
+    }
+  },
+  "Porygon2": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "Download",
+      "item": "Eviolite",
+      "moves": [
+        "Ice Beam",
+        "",
+        "",
+        "Tri Attack"
+      ]
+    }
+  },
+  "Stantler": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Sassy",
+      "ability": "Intimidate",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Smeargle": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Hitmontop": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Intimidate",
+      "item": "",
+      "moves": [
+        "Fake Out",
+        "Close Combat",
+        "",
+        ""
+      ]
+    }
+  },
+  "Arbok": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Intimidate",
+      "item": "Life Orb",
+      "moves": [
+        "Gunk Shot",
+        "Sucker Punch",
+        "",
+        "Earthquake"
+      ]
+    }
+  },
+  "Miltank": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Careful",
+      "ability": "Thick Fat",
+      "item": "Leftovers",
+      "moves": [
+        "",
+        "",
+        "",
+        "Rock Slide"
+      ]
+    }
+  },
+  "Blissey": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "",
+      "item": "Kee Berry",
+      "moves": [
+        "",
+        "",
+        "Flamethrower",
+        ""
+      ]
+    }
+  },
+  "Raikou": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "",
+      "item": "Life Orb",
+      "moves": [
+        "Thunderbolt",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Entei": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "",
+      "item": "Leftovers",
+      "moves": [
+        "Sacred Fire",
+        "Stone Edge",
+        "",
+        "Bulldoze"
+      ]
+    }
+  },
+  "Suicune": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Scald",
+        "",
+        "Ice Beam",
+        "Snarl"
+      ]
+    }
+  },
+  "Larvitar": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "Guts",
+      "item": "Flame Orb",
+      "moves": [
+        "",
+        "Crunch",
+        "",
+        "Rock Slide"
+      ]
+    }
+  },
+  "Tyranitar": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "Sand Stream",
+      "item": "Choice Scarf",
+      "moves": [
+        "Rock Slide",
+        "Crunch",
+        "",
+        "Low Kick"
+      ]
+    }
+  },
+  "Pikachu": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Quiet",
+      "ability": "Lightning Rod",
+      "item": "Light Ball",
+      "moves": [
+        "Flying Press",
+        "Feint",
+        "Iron Tail",
+        "Thunderbolt"
+      ]
+    }
+  },
+  "Treecko": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Naive",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        "Quick Attack"
+      ]
+    }
+  },
+  "Sceptile": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Overgrow",
+      "item": "Sceptilite",
+      "moves": [
+        "Dragon Pulse",
+        "Leaf Storm",
+        "",
+        ""
+      ]
+    }
+  },
+  "Blaziken": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "",
+      "item": "Blazikenite",
+      "moves": [
+        "",
+        "Flare Blitz",
+        "Rock Slide",
+        "Superpower"
+      ]
+    }
+  },
+  "Marshtomp": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Impish",
+      "ability": "Torrent",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "Brick Break",
+        "",
+        ""
+      ]
+    }
+  },
+  "Raichu": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Lightning Rod",
+      "item": "",
+      "moves": [
+        "Fake Out",
+        "",
+        "Thunderbolt",
+        ""
+      ]
+    }
+  },
+  "Swampert": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Torrent",
+      "item": "Swampertite",
+      "moves": [
+        "Waterfall",
+        "",
+        "Earthquake",
+        "Ice Punch"
+      ]
+    }
+  },
+  "Mightyena": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Intimidate",
+      "item": "Choice Scarf",
+      "moves": [
+        "Snarl",
+        "Foul Play",
+        "",
+        ""
+      ]
+    }
+  },
+  "Linoone": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Extreme Speed",
+        "",
+        "Shadow Claw",
+        ""
+      ]
+    }
+  },
+  "Ludicolo": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Swift Swim",
+      "item": "Assault Vest",
+      "moves": [
+        "Fake Out",
+        "Ice Beam",
+        "Giga Drain",
+        "Scald"
+      ]
+    }
+  },
+  "Shiftry": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Hasty",
+      "ability": "Chlorophyll",
+      "item": "",
+      "moves": [
+        "Fake Out",
+        "Leaf Storm",
+        "",
+        "Icy Wind"
+      ]
+    }
+  },
+  "Taillow": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "Scrappy",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        "Quick Attack"
+      ]
+    }
+  },
+  "Swellow": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "Guts",
+      "item": "Flame Orb",
+      "moves": [
+        "",
+        "",
+        "Brave Bird",
+        "Facade"
+      ]
+    }
+  },
+  "Pelipper": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "Rain Dish",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Scald",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Sandslash": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "Sand Rush",
+      "item": "",
+      "moves": [
+        "Rock Slide",
+        "Knock Off",
+        "",
+        ""
+      ]
+    }
+  },
+  "Ralts": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "",
+      "item": "",
+      "moves": [
+        ""
+      ]
+    }
+  },
+  "Gardevoir": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "",
+      "item": "Gardevoirite",
+      "moves": [
+        "",
+        "Hyper Voice",
+        "Psychic",
+        "Psyshock"
+      ]
+    }
+  },
+  "Surskit": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Swift Swim",
+      "item": "",
+      "moves": [
+        "Scald",
+        "Aqua Jet",
+        "",
+        "Blizzard"
+      ]
+    }
+  },
+  "Masquerain": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Intimidate",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "Air Slash",
+        ""
+      ]
+    }
+  },
+  "Breloom": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "Technician",
+      "item": "",
+      "moves": [
+        "Spark",
+        "Bullet Seed",
+        "Mach Punch",
+        ""
+      ]
+    }
+  },
+  "Slaking": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "",
+      "item": "Choice Scarf",
+      "moves": [
+        "Earthquake",
+        "Giga Impact",
+        "Low Kick",
+        "Ice Punch"
+      ]
+    }
+  },
+  "Ninjask": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        "X-Scissor"
+      ]
+    }
+  },
+  "Shedinja": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Lonely",
+      "ability": "Wonder Guard",
+      "item": "",
+      "moves": [
+        "Shadow Sneak",
+        "",
+        "Bug Bite",
+        ""
+      ]
+    }
+  },
+  "Exploud": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Quiet",
+      "ability": "Soundproof",
+      "item": "Choice Specs",
+      "moves": [
+        "Boomburst",
+        "Ice Beam",
+        "Flamethrower",
+        "Surf"
+      ]
+    }
+  },
+  "Hariyama": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Brave",
+      "ability": "Guts",
+      "item": "Assault Vest",
+      "moves": [
+        "Fake Out",
+        "Close Combat",
+        "Knock Off",
+        "Rock Slide"
+      ]
+    }
+  },
+  "Nosepass": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Hasty",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Venusaur": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Chlorophyll",
+      "item": "Venusaurite",
+      "moves": [
+        "Sludge Bomb",
+        "",
+        "Giga Drain",
+        ""
+      ]
+    }
+  },
+  "Delcatty": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "Normalize",
+      "item": "Chople Berry",
+      "moves": [
+        "Fake Out",
+        "Return",
+        "",
+        ""
+      ]
+    }
+  },
+  "Sableye": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        "Fake Out"
+      ]
+    }
+  },
+  "Mawile": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Intimidate",
+      "item": "Mawilite",
+      "moves": [
+        "Sucker Punch",
+        "Play Rough",
+        "Iron Head",
+        ""
+      ]
+    }
+  },
+  "Aron": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Careful",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Aggron": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Careful",
+      "ability": "",
+      "item": "Aggronite",
+      "moves": [
+        "Heavy Slam",
+        "Rock Slide",
+        "Iron Head",
+        ""
+      ]
+    }
+  },
+  "Medicham": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Pure Power",
+      "item": "Medichamite",
+      "moves": [
+        "Drain Punch",
+        "",
+        "Psycho Cut",
+        "Fake Out"
+      ]
+    }
+  },
+  "Nidoqueen": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Sheer Force",
+      "item": "Life Orb",
+      "moves": [
+        "Earth Power",
+        "Sludge Bomb",
+        "Ice Beam",
+        ""
+      ]
+    }
+  },
+  "Manectric": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Lightning Rod",
+      "item": "Manectite",
+      "moves": [
+        "",
+        "",
+        "Volt Switch",
+        "Thunderbolt"
+      ]
+    }
+  },
+  "Plusle": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "",
+        "",
+        "",
+        "Thunderbolt"
+      ]
+    }
+  },
+  "Minun": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "",
+      "item": "Choice Scarf",
+      "moves": [
+        "Grass Knot",
+        "Electro Ball",
+        "",
+        ""
+      ]
+    }
+  },
+  "Volbeat": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Illumise": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Sharpedo": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "",
+      "item": "Sharpedonite",
+      "moves": [
+        "",
+        "Crunch",
+        "Waterfall",
+        "Ice Fang"
+      ]
+    }
+  },
+  "Wailord": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "",
+      "item": "Choice Scarf",
+      "moves": [
+        "Water Spout",
+        "Ice Beam",
+        "",
+        "Scald"
+      ]
+    }
+  },
+  "Numel": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "Simple",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "Ancient Power",
+        "",
+        ""
+      ]
+    }
+  },
+  "Camerupt": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Quiet",
+      "ability": "Solid Rock",
+      "item": "Cameruptite",
+      "moves": [
+        "Earth Power",
+        "",
+        "Heat Wave",
+        "Ancient Power"
+      ]
+    }
+  },
+  "Torkoal": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Quiet",
+      "ability": "White Smoke",
+      "item": "Flame Plate",
+      "moves": [
+        "Eruption",
+        "",
+        "Earth Power",
+        "Sludge Bomb"
+      ]
+    }
+  },
+  "Grumpig": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "Thick Fat",
+      "item": "",
+      "moves": [
+        "Power Gem",
+        "Psychic",
+        "",
+        ""
+      ]
+    }
+  },
+  "Spinda": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "Contrary",
+      "item": "Choice Scarf",
+      "moves": [
+        "",
+        "Icy Wind",
+        "Fake Out",
+        ""
+      ]
+    }
+  },
+  "Flygon": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Levitate",
+      "item": "",
+      "moves": [
+        "",
+        "Feint",
+        "Earthquake",
+        "Earth Power"
+      ]
+    }
+  },
+  "Cacturne": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Sand Veil",
+      "item": "Expert Belt",
+      "moves": [
+        "",
+        "Seed Bomb",
+        "Sucker Punch",
+        "Low Kick"
+      ]
+    }
+  },
+  "Altaria": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Cloud Nine",
+      "item": "Altarianite",
+      "moves": [
+        "Hyper Voice",
+        "",
+        "Fire Blast",
+        ""
+      ]
+    }
+  },
+  "Zangoose": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "Toxic Boost",
+      "item": "Toxic Orb",
+      "moves": [
+        "",
+        "Close Combat",
+        "Facade",
+        "Fire Punch"
+      ]
+    }
+  },
+  "Seviper": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Quiet",
+      "ability": "Infiltrator",
+      "item": "Expert Belt",
+      "moves": [
+        "Flamethrower",
+        "",
+        "Poison Jab",
+        ""
+      ]
+    }
+  },
+  "Lunatone": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Levitate",
+      "item": "Assault Vest",
+      "moves": [
+        "Moonblast",
+        "Earth Power",
+        "Psychic",
+        "Ice Beam"
+      ]
+    }
+  },
+  "Solrock": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Impish",
+      "ability": "Levitate",
+      "item": "",
+      "moves": [
+        "",
+        "Rock Tomb",
+        "",
+        ""
+      ]
+    }
+  },
+  "Nidoking": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Sheer Force",
+      "item": "Life Orb",
+      "moves": [
+        "Earth Power",
+        "Ice Beam",
+        "Sludge Bomb",
+        ""
+      ]
+    }
+  },
+  "Crawdaunt": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Adaptability",
+      "item": "Life Orb",
+      "moves": [
+        "Knock Off",
+        "Aqua Jet",
+        "Crabhammer",
+        ""
+      ]
+    }
+  },
+  "Claydol": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Levitate",
+      "item": "",
+      "moves": [
+        "Earth Power",
+        "Ice Beam",
+        "Psyshock",
+        ""
+      ]
+    }
+  },
+  "Lileep": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Relaxed",
+      "ability": "Storm Drain",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Cradily": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Quiet",
+      "ability": "Storm Drain",
+      "item": "Leftovers",
+      "moves": [
+        "Ancient Power",
+        "Giga Drain",
+        "",
+        "Energy Ball"
+      ]
+    }
+  },
+  "Armaldo": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Brave",
+      "ability": "Battle Armor",
+      "item": "",
+      "moves": [
+        "X-Scissor",
+        "Rock Slide",
+        "Aqua Jet",
+        "Knock Off"
+      ]
+    }
+  },
+  "Clefairy": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "",
+        "",
+        "Icy Wind"
+      ]
+    }
+  },
+  "Milotic": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Scald",
+        "Ice Beam",
+        "Icy Wind",
+        ""
+      ]
+    }
+  },
+  "Castform": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Forecast",
+      "item": "Life Orb",
+      "moves": [
+        "Weather Ball",
+        "Thunder",
+        "",
+        ""
+      ]
+    }
+  },
+  "Kecleon": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Protean",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Fake Out",
+        "Shadow Sneak",
+        "Sucker Punch",
+        ""
+      ]
+    }
+  },
+  "Banette": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Careful",
+      "ability": "",
+      "item": "Banettite",
+      "moves": [
+        "",
+        "",
+        "",
+        "Shadow Sneak"
+      ]
+    }
+  },
+  "Dusclops": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Sassy",
+      "ability": "",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "",
+        "",
+        "Night Shade"
+      ]
+    }
+  },
+  "Chimecho": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Levitate",
+      "item": "",
+      "moves": [
+        "Icy Wind",
+        "",
+        "",
+        "Psychic"
+      ]
+    }
+  },
+  "Absol": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "",
+      "item": "Absolite",
+      "moves": [
+        "Sucker Punch",
+        "Play Rough",
+        "Knock Off",
+        ""
+      ]
+    }
+  },
+  "Clefable": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "Magic Guard",
+      "item": "Sitrus Berry",
+      "moves": [
+        "",
+        "",
+        "Moonblast",
+        ""
+      ]
+    }
+  },
+  "Wynaut": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Impish",
+      "ability": "",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Glalie": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "",
+      "item": "Glalitite",
+      "moves": [
+        "",
+        "Explosion",
+        "Ice Shard",
+        "Return"
+      ]
+    }
+  },
+  "Walrein": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "Ice Body",
+      "item": "Chesto Berry",
+      "moves": [
+        "Icy Wind",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Clamperl": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Shell Armor",
+      "item": "Deep Sea Tooth",
+      "moves": [
+        "",
+        "Ice Beam",
+        "",
+        "Surf"
+      ]
+    }
+  },
+  "Huntail": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "Sucker Punch",
+        "",
+        "Waterfall"
+      ]
+    }
+  },
+  "Gorebyss": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Calm",
+      "ability": "Swift Swim",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "Surf",
+        "Muddy Water"
+      ]
+    }
+  },
+  "Relicanth": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "",
+      "item": "Choice Band",
+      "moves": [
+        "Head Smash",
+        "Waterfall",
+        "Earthquake",
+        ""
+      ]
+    }
+  },
+  "Vulpix": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Brave",
+      "ability": "Drought",
+      "item": "Eviolite",
+      "moves": [
+        "Foul Play",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Salamence": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Intimidate",
+      "item": "Salamencite",
+      "moves": [
+        "",
+        "Double-Edge",
+        "Earthquake",
+        ""
+      ]
+    }
+  },
+  "Metagross": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Clear Body",
+      "item": "Metagrossite",
+      "moves": [
+        "Zen Headbutt",
+        "",
+        "Ice Punch",
+        "Meteor Mash"
+      ]
+    }
+  },
+  "Regirock": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Clear Body",
+      "item": "Assault Vest",
+      "moves": [
+        "Rock Slide",
+        "Ice Punch",
+        "Drain Punch",
+        "Earthquake"
+      ]
+    }
+  },
+  "Regice": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "Clear Body",
+      "item": "Lum Berry",
+      "moves": [
+        "Ice Beam",
+        "Thunderbolt",
+        "Focus Blast",
+        ""
+      ]
+    }
+  },
+  "Registeel": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Careful",
+      "ability": "Clear Body",
+      "item": "Leftovers",
+      "moves": [
+        "Iron Head",
+        "",
+        "",
+        "Earthquake"
+      ]
+    }
+  },
+  "Ninetales": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Drought",
+      "item": "",
+      "moves": [
+        "",
+        "Solar Beam",
+        "Heat Wave",
+        ""
+      ]
+    }
+  },
+  "Latias": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Levitate",
+      "item": "Latiasite",
+      "moves": [
+        "Psychic",
+        "",
+        "Ice Beam",
+        "Draco Meteor"
+      ]
+    }
+  },
+  "Latios": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Levitate",
+      "item": "Choice Scarf",
+      "moves": [
+        "Draco Meteor",
+        "Ice Beam",
+        "Psychic",
+        "Psyshock"
+      ]
+    }
+  },
+  "Torterra": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Brave",
+      "ability": "Overgrow",
+      "item": "Assault Vest",
+      "moves": [
+        "Earthquake",
+        "Wood Hammer",
+        "Stone Edge",
+        "Rock Slide"
+      ]
+    }
+  },
+  "Jigglypuff": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Relaxed",
+      "ability": "",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Infernape": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Naive",
+      "ability": "Blaze",
+      "item": "",
+      "moves": [
+        "Close Combat",
+        "Fake Out",
+        "Overheat",
+        ""
+      ]
+    }
+  },
+  "Piplup": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "Torrent",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "Icy Wind",
+        "",
+        "Hydro Pump"
+      ]
+    }
+  },
+  "Empoleon": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Torrent",
+      "item": "Assault Vest",
+      "moves": [
+        "Flash Cannon",
+        "Ice Beam",
+        "",
+        "Aqua Jet"
+      ]
+    }
+  },
+  "Staraptor": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "Intimidate",
+      "item": "Choice Scarf",
+      "moves": [
+        "Brave Bird",
+        "Close Combat",
+        "U-turn",
+        ""
+      ]
+    }
+  },
+  "Wigglytuff": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "",
+      "item": "Assault Vest",
+      "moves": [
+        "Dazzling Gleam",
+        "Fire Blast",
+        "Thunderbolt",
+        "Hyper Voice"
+      ]
+    }
+  },
+  "Bibarel": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Careful",
+      "ability": "Simple",
+      "item": "",
+      "moves": [
+        "Waterfall",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Luxray": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Calm",
+      "ability": "Intimidate",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Volt Switch",
+        "Snarl",
+        "",
+        ""
+      ]
+    }
+  },
+  "Roserade": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Technician",
+      "item": "Choice Scarf",
+      "moves": [
+        "Sludge Bomb",
+        "",
+        "Leaf Storm",
+        ""
+      ]
+    }
+  },
+  "Rampardos": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Sheer Force",
+      "item": "Choice Band",
+      "moves": [
+        "Rock Slide",
+        "Head Smash",
+        "Iron Head",
+        "Fire Punch"
+      ]
+    }
+  },
+  "Bastiodon": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Careful",
+      "ability": "Soundproof",
+      "item": "Leftovers",
+      "moves": [
+        "",
+        "",
+        "Iron Head",
+        "Pluck"
+      ]
+    }
+  },
+  "Pachirisu": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Impish",
+      "ability": "Volt Absorb",
+      "item": "Sitrus Berry",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Floatzel": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Swift Swim",
+      "item": "",
+      "moves": [
+        "",
+        "Spark",
+        "Ice Beam",
+        "Hydro Pump"
+      ]
+    }
+  },
+  "Golbat": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Careful",
+      "ability": "",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Cherrim": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "Flower Gift",
+      "item": "Leftovers",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Gastrodon": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "Storm Drain",
+      "item": "Leftovers",
+      "moves": [
+        "Earth Power",
+        "",
+        "Ice Beam",
+        "Scald"
+      ]
+    }
+  },
+  "Ambipom": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "Technician",
+      "item": "Life Orb",
+      "moves": [
+        "Fake Out",
+        "Double Hit",
+        "",
+        "Knock Off"
+      ]
+    }
+  },
+  "Drifblim": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "",
+      "item": "Lum Berry",
+      "moves": [
+        "",
+        "",
+        "Shadow Ball",
+        "Weather Ball"
+      ]
+    }
+  },
+  "Buneary": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "",
+      "item": "Choice Scarf",
+      "moves": [
+        "",
+        "",
+        "",
+        "Jump Kick"
+      ]
+    }
+  },
+  "Lopunny": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "",
+      "item": "Lopunnite",
+      "moves": [
+        "Fake Out",
+        "Return",
+        "Ice Punch",
+        "Low Kick"
+      ]
+    }
+  },
+  "Mismagius": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Levitate",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "Shadow Ball",
+        "Icy Wind"
+      ]
+    }
+  },
+  "Honchkrow": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "Sucker Punch",
+        "Brave Bird",
+        "Night Slash",
+        "Superpower"
+      ]
+    }
+  },
+  "Purugly": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "Defiant",
+      "item": "Life Orb",
+      "moves": [
+        "Fake Out",
+        "",
+        "Play Rough",
+        "Sucker Punch"
+      ]
+    }
+  },
+  "Skuntank": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "",
+      "item": "Black Sludge",
+      "moves": [
+        "Foul Play",
+        "Snarl",
+        "",
+        ""
+      ]
+    }
+  },
+  "Bronzor": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Sassy",
+      "ability": "Heatproof",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "Psychic",
+        "",
+        ""
+      ]
+    }
+  },
+  "Bronzong": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Sassy",
+      "ability": "Levitate",
+      "item": "Lum Berry",
+      "moves": [
+        "",
+        "",
+        "Iron Head",
+        ""
+      ]
+    }
+  },
+  "Mime Jr.": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Relaxed",
+      "ability": "Filter",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Chatot": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "",
+      "item": "Choice Scarf",
+      "moves": [
+        "Chatter",
+        "",
+        "",
+        "Boomburst"
+      ]
+    }
+  },
+  "Spiritomb": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Sassy",
+      "ability": "Infiltrator",
+      "item": "Leftovers",
+      "moves": [
+        "",
+        "",
+        "Snarl",
+        ""
+      ]
+    }
+  },
+  "Garchomp": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "",
+      "item": "Lum Berry",
+      "moves": [
+        "Earthquake",
+        "Rock Slide",
+        "Dragon Claw",
+        ""
+      ]
+    }
+  },
+  "Riolu": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Naive",
+      "ability": "",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "",
+        "",
+        "Feint"
+      ]
+    }
+  },
+  "Lucario": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "",
+      "item": "Lucarionite",
+      "moves": [
+        "",
+        "Close Combat",
+        "Bullet Punch",
+        "Flash Cannon"
+      ]
+    }
+  },
+  "Vileplume": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Quiet",
+      "ability": "",
+      "item": "Assault Vest",
+      "moves": [
+        "Sludge Bomb",
+        "Moonblast",
+        "Giga Drain",
+        ""
+      ]
+    }
+  },
+  "Hippowdon": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Impish",
+      "ability": "Sand Stream",
+      "item": "",
+      "moves": [
+        "Earthquake",
+        "",
+        "Ice Fang",
+        ""
+      ]
+    }
+  },
+  "Drapion": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Sniper",
+      "item": "",
+      "moves": [
+        "Knock Off",
+        "Cross Poison",
+        "",
+        ""
+      ]
+    }
+  },
+  "Toxicroak": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Dry Skin",
+      "item": "",
+      "moves": [
+        "Drain Punch",
+        "Fake Out",
+        "Poison Jab",
+        ""
+      ]
+    }
+  },
+  "Carnivine": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Lax",
+      "ability": "Levitate",
+      "item": "",
+      "moves": [
+        "",
+        "Crunch",
+        "",
+        ""
+      ]
+    }
+  },
+  "Lumineon": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Storm Drain",
+      "item": "Sitrus Berry",
+      "moves": [
+        "",
+        "Scald",
+        "Spark",
+        ""
+      ]
+    }
+  },
+  "Mantyke": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Calm",
+      "ability": "Water Absorb",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "Scald",
+        "",
+        ""
+      ]
+    }
+  },
+  "Paras": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Impish",
+      "ability": "Dry Skin",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "",
+        "X-Scissor",
+        "Spark"
+      ]
+    }
+  },
+  "Abomasnow": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Quiet",
+      "ability": "Snow Warning",
+      "item": "Abomasite",
+      "moves": [
+        "Blizzard",
+        "",
+        "Ice Shard",
+        "Energy Ball"
+      ]
+    }
+  },
+  "Weavile": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "Fake Out",
+        "Knock Off",
+        "Low Kick",
+        "Icicle Crash"
+      ]
+    }
+  },
+  "Magnezone": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "",
+      "item": "Choice Specs",
+      "moves": [
+        "Flash Cannon",
+        "Thunderbolt",
+        "",
+        ""
+      ]
+    }
+  },
+  "Lickilicky": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Cloud Nine",
+      "item": "Life Orb",
+      "moves": [
+        "",
+        "Explosion",
+        "Knock Off",
+        "Thunderbolt"
+      ]
+    }
+  },
+  "Rhyperior": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Brave",
+      "ability": "Solid Rock",
+      "item": "",
+      "moves": [
+        "Rock Slide",
+        "Earthquake",
+        "",
+        "Ice Punch"
+      ]
+    }
+  },
+  "Tangrowth": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "Giga Drain",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Electivire": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Motor Drive",
+      "item": "Expert Belt",
+      "moves": [
+        "Ice Punch",
+        "Earthquake",
+        "",
+        "Wild Charge"
+      ]
+    }
+  },
+  "Magmortar": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "",
+      "item": "Expert Belt",
+      "moves": [
+        "",
+        "Thunderbolt",
+        "",
+        "Flamethrower"
+      ]
+    }
+  },
+  "Togekiss": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Air Slash",
+        "",
+        "Dazzling Gleam",
+        ""
+      ]
+    }
+  },
+  "Yanmega": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "Air Slash",
+        "",
+        "Bug Buzz",
+        "Giga Drain"
+      ]
+    }
+  },
+  "Parasect": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Sassy",
+      "ability": "Dry Skin",
+      "item": "",
+      "moves": [
+        "Spark",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Leafeon": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Chlorophyll",
+      "item": "",
+      "moves": [
+        "Leaf Blade",
+        "Knock Off",
+        "Natural Gift",
+        ""
+      ]
+    }
+  },
+  "Glaceon": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Snow Cloak",
+      "item": "Choice Specs",
+      "moves": [
+        "Blizzard",
+        "Shadow Ball",
+        "",
+        "Ice Beam"
+      ]
+    }
+  },
+  "Gliscor": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Impish",
+      "ability": "Poison Heal",
+      "item": "Toxic Orb",
+      "moves": [
+        "Earthquake",
+        "",
+        "Knock Off",
+        ""
+      ]
+    }
+  },
+  "Mamoswine": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Thick Fat",
+      "item": "Choice Scarf",
+      "moves": [
+        "Earthquake",
+        "Icicle Crash",
+        "Rock Slide",
+        "Ice Shard"
+      ]
+    }
+  },
+  "Porygon-Z": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Adaptability",
+      "item": "Choice Scarf",
+      "moves": [
+        "Tri Attack",
+        "Ice Beam",
+        "Dark Pulse",
+        "Thunderbolt"
+      ]
+    }
+  },
+  "Gallade": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "",
+      "item": "Galladite",
+      "moves": [
+        "Close Combat",
+        "",
+        "Ice Punch",
+        "Zen Headbutt"
+      ]
+    }
+  },
+  "Probopass": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Quiet",
+      "ability": "",
+      "item": "Leftovers",
+      "moves": [
+        "",
+        "Power Gem",
+        "Earth Power",
+        "Discharge"
+      ]
+    }
+  },
+  "Dusknoir": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Sassy",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        "Night Shade"
+      ]
+    }
+  },
+  "Froslass": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "Shadow Ball",
+        "",
+        "Icy Wind"
+      ]
+    }
+  },
+  "Rotom": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Levitate",
+      "item": "Sitrus Berry",
+      "moves": [
+        "",
+        "Thunderbolt",
+        "",
+        "Shadow Ball"
+      ]
+    }
+  },
+  "Rotom-H": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Levitate",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Overheat",
+        "Thunderbolt",
+        "",
+        ""
+      ]
+    }
+  },
+  "Rotom-W": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Levitate",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Hydro Pump",
+        "Thunderbolt",
+        "",
+        ""
+      ]
+    }
+  },
+  "Rotom-F": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Levitate",
+      "item": "Choice Scarf",
+      "moves": [
+        "Blizzard",
+        "Thunderbolt",
+        "Volt Switch",
+        ""
+      ]
+    }
+  },
+  "Rotom-S": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Levitate",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Air Slash",
+        "",
+        "",
+        "Thunderbolt"
+      ]
+    }
+  },
+  "Rotom-C": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Levitate",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Leaf Storm",
+        "Thunderbolt",
+        "",
+        ""
+      ]
+    }
+  },
+  "Uxie": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "Levitate",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        "Psyshock"
+      ]
+    }
+  },
+  "Mesprit": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Levitate",
+      "item": "Colbur Berry",
+      "moves": [
+        "Ice Beam",
+        "",
+        "Psychic",
+        "Thunderbolt"
+      ]
+    }
+  },
+  "Azelf": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Levitate",
+      "item": "",
+      "moves": [
+        "Psychic",
+        "Flamethrower",
+        "Dazzling Gleam",
+        "Fire Blast"
+      ]
+    }
+  },
+  "Heatran": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Flash Fire",
+      "item": "Leftovers",
+      "moves": [
+        "",
+        "Heat Wave",
+        "Earth Power",
+        "Flash Cannon"
+      ]
+    }
+  },
+  "Regigigas": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Slow Start",
+      "item": "Leftovers",
+      "moves": [
+        "",
+        "Rock Slide",
+        "Drain Punch",
+        "Return"
+      ]
+    }
+  },
+  "Cresselia": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "Levitate",
+      "item": "",
+      "moves": [
+        "Psychic",
+        "Ice Beam",
+        "",
+        ""
+      ]
+    }
+  },
+  "Venomoth": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "",
+      "item": "Black Sludge",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Servine": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "Contrary",
+      "item": "Eviolite",
+      "moves": [
+        "Leaf Storm",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Serperior": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Contrary",
+      "item": "",
+      "moves": [
+        "Leaf Storm",
+        "",
+        "",
+        "Dragon Pulse"
+      ]
+    }
+  },
+  "Pignite": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Careful",
+      "ability": "Thick Fat",
+      "item": "Eviolite",
+      "moves": [
+        "Flare Blitz",
+        "Superpower",
+        "",
+        ""
+      ]
+    }
+  },
+  "Emboar": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Brave",
+      "ability": "Reckless",
+      "item": "Life Orb",
+      "moves": [
+        "Flare Blitz",
+        "Head Smash",
+        "Wild Charge",
+        "Sucker Punch"
+      ]
+    }
+  },
+  "Samurott": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Torrent",
+      "item": "Wacan Berry",
+      "moves": [
+        "Ice Beam",
+        "Grass Knot",
+        "Scald",
+        ""
+      ]
+    }
+  },
+  "Stoutland": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Sand Rush",
+      "item": "Life Orb",
+      "moves": [
+        "Crunch",
+        "Retaliate",
+        "Return",
+        "Play Rough"
+      ]
+    }
+  },
+  "Purrloin": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        "Fake Out"
+      ]
+    }
+  },
+  "Dugtrio": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "Sucker Punch",
+        "Rock Slide",
+        "",
+        ""
+      ]
+    }
+  },
+  "Liepard": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "Fake Out",
+        "Foul Play",
+        ""
+      ]
+    }
+  },
+  "Musharna": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Relaxed",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "",
+        "",
+        "Psychic",
+        ""
+      ]
+    }
+  },
+  "Unfezant": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "Night Slash",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Zebstrika": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Lightning Rod",
+      "item": "Life Orb",
+      "moves": [
+        "",
+        "Thunderbolt",
+        "Overheat",
+        ""
+      ]
+    }
+  },
+  "Gigalith": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Brave",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "Rock Slide",
+        "Earthquake",
+        "Heavy Slam",
+        "Explosion"
+      ]
+    }
+  },
+  "Swoobat": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Simple",
+      "item": "",
+      "moves": [
+        "Stored Power",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Persian": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "Fake Out",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Excadrill": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Mold Breaker",
+      "item": "Life Orb",
+      "moves": [
+        "Iron Head",
+        "Rock Slide",
+        "Earthquake",
+        ""
+      ]
+    }
+  },
+  "Audino": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Relaxed",
+      "ability": "",
+      "item": "Audinite",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Gurdurr": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Guts",
+      "item": "Eviolite",
+      "moves": [
+        "Drain Punch",
+        "Knock Off",
+        "",
+        "Mach Punch"
+      ]
+    }
+  },
+  "Conkeldurr": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Guts",
+      "item": "Assault Vest",
+      "moves": [
+        "Mach Punch",
+        "Drain Punch",
+        "Ice Punch",
+        "Knock Off"
+      ]
+    }
+  },
+  "Tympole": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Swift Swim",
+      "item": "Choice Specs",
+      "moves": [
+        "Earth Power",
+        "",
+        "Sludge Bomb",
+        "Hydro Pump"
+      ]
+    }
+  },
+  "Seismitoad": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Swift Swim",
+      "item": "Life Orb",
+      "moves": [
+        "Earth Power",
+        "",
+        "Muddy Water",
+        ""
+      ]
+    }
+  },
+  "Throh": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Impish",
+      "ability": "",
+      "item": "Leftovers",
+      "moves": [
+        "Storm Throw",
+        "",
+        "Knock Off",
+        "Ice Punch"
+      ]
+    }
+  },
+  "Sawk": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "",
+      "item": "Choice Scarf",
+      "moves": [
+        "Close Combat",
+        "Ice Punch",
+        "Rock Slide",
+        "Poison Jab"
+      ]
+    }
+  },
+  "Leavanny": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Chlorophyll",
+      "item": "",
+      "moves": [
+        "X-Scissor",
+        "Leaf Blade",
+        "",
+        "Knock Off"
+      ]
+    }
+  },
+  "Scolipede": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "",
+      "item": "Life Orb",
+      "moves": [
+        "Poison Jab",
+        "",
+        "Rock Slide",
+        "Earthquake"
+      ]
+    }
+  },
+  "Whimsicott": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Lilligant": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Chlorophyll",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "Solar Beam",
+        ""
+      ]
+    }
+  },
+  "Golduck": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Cloud Nine",
+      "item": "Leftovers",
+      "moves": [
+        "",
+        "Scald",
+        "Icy Wind",
+        "Ice Beam"
+      ]
+    }
+  },
+  "Basculin": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Adaptability",
+      "item": "Choice Band",
+      "moves": [
+        "Aqua Jet",
+        "Superpower",
+        "Crunch",
+        "Waterfall"
+      ]
+    }
+  },
+  "Krookodile": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Intimidate",
+      "item": "Choice Scarf",
+      "moves": [
+        "Earthquake",
+        "Rock Slide",
+        "Knock Off",
+        ""
+      ]
+    }
+  },
+  "Darmanitan": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Sheer Force",
+      "item": "Choice Scarf",
+      "moves": [
+        "Flare Blitz",
+        "Superpower",
+        "Rock Slide",
+        "U-turn"
+      ]
+    }
+  },
+  "Maractus": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Storm Drain",
+      "item": "",
+      "moves": [
+        "",
+        "Solar Beam",
+        "Energy Ball",
+        "Giga Drain"
+      ]
+    }
+  },
+  "Crustle": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "",
+      "item": "Lum Berry",
+      "moves": [
+        "",
+        "",
+        "Rock Slide",
+        "Earthquake"
+      ]
+    }
+  },
+  "Scraggy": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Brave",
+      "ability": "Intimidate",
+      "item": "Eviolite",
+      "moves": [
+        "Drain Punch",
+        "",
+        "Knock Off",
+        "Ice Punch"
+      ]
+    }
+  },
+  "Scrafty": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Intimidate",
+      "item": "Lum Berry",
+      "moves": [
+        "Fake Out",
+        "Drain Punch",
+        "Knock Off",
+        "Crunch"
+      ]
+    }
+  },
+  "Sigilyph": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Tinted Lens",
+      "item": "Choice Scarf",
+      "moves": [
+        "Psychic",
+        "Ice Beam",
+        "Dazzling Gleam",
+        "Air Slash"
+      ]
+    }
+  },
+  "Cofagrigus": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Relaxed",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "Shadow Ball",
+        ""
+      ]
+    }
+  },
+  "Carracosta": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Brave",
+      "ability": "Solid Rock",
+      "item": "",
+      "moves": [
+        "",
+        "Aqua Jet",
+        "Rock Slide",
+        "Ice Beam"
+      ]
+    }
+  },
+  "Archeops": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "Defeatist",
+      "item": "",
+      "moves": [
+        "Rock Slide",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Primeape": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Defiant",
+      "item": "Choice Scarf",
+      "moves": [
+        "Close Combat",
+        "Ice Punch",
+        "Rock Slide",
+        "Gunk Shot"
+      ]
+    }
+  },
+  "Zorua": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Rash",
+      "ability": "",
+      "item": "Life Orb",
+      "moves": [
+        "Snarl",
+        "Night Daze",
+        "",
+        ""
+      ]
+    }
+  },
+  "Zoroark": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "Flamethrower",
+        "",
+        "Night Daze",
+        "Dark Pulse"
+      ]
+    }
+  },
+  "Cinccino": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "Skill Link",
+      "item": "King's Rock",
+      "moves": [
+        "Rock Blast",
+        "Bullet Seed",
+        "Tail Slap",
+        ""
+      ]
+    }
+  },
+  "Gothorita": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Calm",
+      "ability": "",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "",
+        "Psychic",
+        ""
+      ]
+    }
+  },
+  "Gothitelle": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Sassy",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "",
+        "",
+        "Psychic",
+        ""
+      ]
+    }
+  },
+  "Solosis": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Quiet",
+      "ability": "Magic Guard",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Duosion": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "",
+      "item": "Eviolite",
+      "moves": [
+        "Psyshock",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Reuniclus": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Quiet",
+      "ability": "Magic Guard",
+      "item": "Life Orb",
+      "moves": [
+        "",
+        "Psychic",
+        "Shadow Ball",
+        "Psyshock"
+      ]
+    }
+  },
+  "Vanilluxe": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Ice Body",
+      "item": "Choice Scarf",
+      "moves": [
+        "Freeze-Dry",
+        "Weather Ball",
+        "",
+        "Ice Beam"
+      ]
+    }
+  },
+  "Sawsbuck": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Chlorophyll",
+      "item": "Life Orb",
+      "moves": [
+        "Horn Leech",
+        "",
+        "Double-Edge",
+        "Jump Kick"
+      ]
+    }
+  },
+  "Emolga": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Motor Drive",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        "Thunderbolt"
+      ]
+    }
+  },
+  "Escavalier": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Brave",
+      "ability": "Overcoat",
+      "item": "Assault Vest",
+      "moves": [
+        "Iron Head",
+        "Drill Run",
+        "Megahorn",
+        "Knock Off"
+      ]
+    }
+  },
+  "Arcanine": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Intimidate",
+      "item": "Life Orb",
+      "moves": [
+        "Extreme Speed",
+        "Flare Blitz",
+        "",
+        "Close Combat"
+      ]
+    }
+  },
+  "Foongus": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "Feint Attack",
+        "Giga Drain"
+      ]
+    }
+  },
+  "Amoonguss": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Relaxed",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "Spark",
+        "",
+        "Giga Drain",
+        ""
+      ]
+    }
+  },
+  "Jellicent": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Quiet",
+      "ability": "Water Absorb",
+      "item": "Sitrus Berry",
+      "moves": [
+        "",
+        "Water Spout",
+        "Shadow Ball",
+        ""
+      ]
+    }
+  },
+  "Alomomola": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Careful",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "Spark",
+        "",
+        "",
+        "Aqua Jet"
+      ]
+    }
+  },
+  "Galvantula": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "Thunder",
+        "Bug Buzz",
+        "Volt Switch",
+        ""
+      ]
+    }
+  },
+  "Ferrothorn": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Brave",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "Power Whip",
+        "Gyro Ball",
+        ""
+      ]
+    }
+  },
+  "Charizard": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Blaze",
+      "item": "Charizardite Y",
+      "moves": [
+        "",
+        "Heat Wave",
+        "Solar Beam",
+        "Overheat"
+      ]
+    }
+  },
+  "Poliwag": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Swift Swim",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        "Surf"
+      ]
+    }
+  },
+  "Klang": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Calm",
+      "ability": "Clear Body",
+      "item": "Eviolite",
+      "moves": [
+        "Gear Grind",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Klinklang": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Clear Body",
+      "item": "Life Orb",
+      "moves": [
+        "Gear Grind",
+        "Wild Charge",
+        "",
+        ""
+      ]
+    }
+  },
+  "Eelektrik": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "Levitate",
+      "item": "Eviolite",
+      "moves": [
+        "Acid Spray",
+        "",
+        "",
+        "Thunderbolt"
+      ]
+    }
+  },
+  "Eelektross": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Quiet",
+      "ability": "Levitate",
+      "item": "Assault Vest",
+      "moves": [
+        "Flamethrower",
+        "Giga Drain",
+        "Thunderbolt",
+        "Volt Switch"
+      ]
+    }
+  },
+  "Beheeyem": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Psychic",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Lampent": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Relaxed",
+      "ability": "Flash Fire",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "",
+        "Heat Wave",
+        "Shadow Ball"
+      ]
+    }
+  },
+  "Chandelure": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Flash Fire",
+      "item": "",
+      "moves": [
+        "Shadow Ball",
+        "Heat Wave",
+        "",
+        ""
+      ]
+    }
+  },
+  "Poliwhirl": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Sassy",
+      "ability": "Swift Swim",
+      "item": "",
+      "moves": [
+        "",
+        "Icy Wind",
+        "",
+        "Surf"
+      ]
+    }
+  },
+  "Haxorus": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Mold Breaker",
+      "item": "Choice Scarf",
+      "moves": [
+        "Earthquake",
+        "Poison Jab",
+        "Dragon Claw",
+        ""
+      ]
+    }
+  },
+  "Beartic": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Swift Swim",
+      "item": "Life Orb",
+      "moves": [
+        "Icicle Crash",
+        "",
+        "Rock Slide",
+        "Low Kick"
+      ]
+    }
+  },
+  "Cryogonal": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Levitate",
+      "item": "Choice Scarf",
+      "moves": [
+        "Freeze-Dry",
+        "Flash Cannon",
+        "Water Pulse",
+        "Icy Wind"
+      ]
+    }
+  },
+  "Accelgor": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Hasty",
+      "ability": "",
+      "item": "Lum Berry",
+      "moves": [
+        "",
+        "",
+        "",
+        "Bug Buzz"
+      ]
+    }
+  },
+  "Stunfisk": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Calm",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "Earth Power",
+        "Thunderbolt",
+        "",
+        "Scald"
+      ]
+    }
+  },
+  "Mienfoo": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "Drain Punch",
+        "",
+        "Fake Out"
+      ]
+    }
+  },
+  "Poliwrath": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Swift Swim",
+      "item": "Expert Belt",
+      "moves": [
+        "Waterfall",
+        "Brick Break",
+        "Poison Jab",
+        "Earthquake"
+      ]
+    }
+  },
+  "Mienshao": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "Fake Out",
+        "",
+        "Rock Slide",
+        "Low Kick"
+      ]
+    }
+  },
+  "Druddigon": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Brave",
+      "ability": "Sheer Force",
+      "item": "Life Orb",
+      "moves": [
+        "Dragon Claw",
+        "Crunch",
+        "",
+        "Rock Slide"
+      ]
+    }
+  },
+  "Golurk": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "",
+      "item": "Life Orb",
+      "moves": [
+        "Dynamic Punch",
+        "",
+        "Earthquake",
+        "Phantom Force"
+      ]
+    }
+  },
+  "Bisharp": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Defiant",
+      "item": "Life Orb",
+      "moves": [
+        "Sucker Punch",
+        "Iron Head",
+        "Knock Off",
+        ""
+      ]
+    }
+  },
+  "Bouffalant": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Brave",
+      "ability": "Reckless",
+      "item": "Choice Band",
+      "moves": [
+        "Head Charge",
+        "Earthquake",
+        "",
+        "Rock Slide"
+      ]
+    }
+  },
+  "Braviary": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Defiant",
+      "item": "Choice Scarf",
+      "moves": [
+        "Brave Bird",
+        "Superpower",
+        "Rock Slide",
+        "U-turn"
+      ]
+    }
+  },
+  "Mandibuzz": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Impish",
+      "ability": "Overcoat",
+      "item": "",
+      "moves": [
+        "Foul Play",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Durant": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "Hustle",
+      "item": "Life Orb",
+      "moves": [
+        "Iron Head",
+        "X-Scissor",
+        "Rock Slide",
+        ""
+      ]
+    }
+  },
+  "Hydreigon": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Levitate",
+      "item": "Choice Specs",
+      "moves": [
+        "Dark Pulse",
+        "Draco Meteor",
+        "Earth Power",
+        "Flamethrower"
+      ]
+    }
+  },
+  "Volcarona": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "Heat Wave",
+        "Bug Buzz",
+        ""
+      ]
+    }
+  },
+  "Cobalion": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "",
+      "item": "Life Orb",
+      "moves": [
+        "Iron Head",
+        "Close Combat",
+        "",
+        "Stone Edge"
+      ]
+    }
+  },
+  "Terrakion": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "",
+      "item": "Lum Berry",
+      "moves": [
+        "Rock Slide",
+        "Close Combat",
+        "",
+        ""
+      ]
+    }
+  },
+  "Virizion": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "",
+      "item": "Life Orb",
+      "moves": [
+        "Close Combat",
+        "Leaf Blade",
+        "",
+        "Stone Edge"
+      ]
+    }
+  },
+  "Tornadus": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "Hurricane",
+        "Heat Wave"
+      ]
+    }
+  },
+  "Tornadus-T": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "",
+      "item": "Life Orb",
+      "moves": [
+        "Hurricane",
+        "",
+        "",
+        "Focus Blast"
+      ]
+    }
+  },
+  "Thundurus": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Thunderbolt",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Thundurus-T": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Volt Absorb",
+      "item": "Choice Scarf",
+      "moves": [
+        "",
+        "Thunderbolt",
+        "Volt Switch",
+        "Grass Knot"
+      ]
+    }
+  },
+  "Landorus": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Sand Force",
+      "item": "Life Orb",
+      "moves": [
+        "",
+        "Rock Slide",
+        "Earthquake",
+        "Earth Power"
+      ]
+    }
+  },
+  "Landorus-T": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Intimidate",
+      "item": "Choice Scarf",
+      "moves": [
+        "Earthquake",
+        "Rock Slide",
+        "Superpower",
+        "U-turn"
+      ]
+    }
+  },
+  "Alakazam": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "",
+      "item": "Alakazite",
+      "moves": [
+        "Psychic",
+        "",
+        "Dazzling Gleam",
+        "Shadow Ball"
+      ]
+    }
+  },
+  "Chesnaught": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Bulletproof",
+      "item": "Lum Berry",
+      "moves": [
+        "",
+        "Wood Hammer",
+        "Feint",
+        ""
+      ]
+    }
+  },
+  "Braixen": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Blaze",
+      "item": "Eviolite",
+      "moves": [
+        "Psyshock",
+        "",
+        "",
+        "Heat Wave"
+      ]
+    }
+  },
+  "Delphox": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Blaze",
+      "item": "Expert Belt",
+      "moves": [
+        "",
+        "Psychic",
+        "Psyshock",
+        "Heat Wave"
+      ]
+    }
+  },
+  "Greninja": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Protean",
+      "item": "Life Orb",
+      "moves": [
+        "Ice Beam",
+        "Gunk Shot",
+        "Dark Pulse",
+        ""
+      ]
+    }
+  },
+  "Diggersby": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Huge Power",
+      "item": "Choice Scarf",
+      "moves": [
+        "Earthquake",
+        "Rock Slide",
+        "Ice Punch",
+        "Return"
+      ]
+    }
+  },
+  "Talonflame": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "",
+      "item": "Life Orb",
+      "moves": [
+        "Brave Bird",
+        "Flare Blitz",
+        "",
+        ""
+      ]
+    }
+  },
+  "Spewpa": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "",
+        "",
+        "Searing Shot"
+      ]
+    }
+  },
+  "Vivillon": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "Hurricane",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Pyroar": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Unnerve",
+      "item": "",
+      "moves": [
+        "Hyper Voice",
+        "",
+        "Overheat",
+        "Dark Pulse"
+      ]
+    }
+  },
+  "Floette": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Calm",
+      "ability": "",
+      "item": "Eviolite",
+      "moves": [
+        "Moonblast",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Florges": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "",
+      "item": "Choice Specs",
+      "moves": [
+        "Moonblast",
+        "Psychic",
+        "Dazzling Gleam",
+        "Energy Ball"
+      ]
+    }
+  },
+  "Gogoat": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Sap Sipper",
+      "item": "",
+      "moves": [
+        "Horn Leech",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Pangoro": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Brave",
+      "ability": "Iron Fist",
+      "item": "",
+      "moves": [
+        "",
+        "Knock Off",
+        "Hammer Arm",
+        "Fire Punch"
+      ]
+    }
+  },
+  "Furfrou": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Fur Coat",
+      "item": "Sitrus Berry",
+      "moves": [
+        "",
+        "Return",
+        "",
+        "Snarl"
+      ]
+    }
+  },
+  "Meowstic": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "",
+      "item": "Colbur Berry",
+      "moves": [
+        "Fake Out",
+        "Psychic",
+        "",
+        "Thunderbolt"
+      ]
+    }
+  },
+  "Machamp": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Dynamic Punch",
+        "Stone Edge",
+        "",
+        ""
+      ]
+    }
+  },
+  "Doublade": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Brave",
+      "ability": "",
+      "item": "Eviolite",
+      "moves": [
+        "Iron Head",
+        "Shadow Sneak",
+        "",
+        ""
+      ]
+    }
+  },
+  "Aegislash": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Quiet",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "Shadow Ball",
+        "Flash Cannon",
+        ""
+      ]
+    }
+  },
+  "Spritzee": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Relaxed",
+      "ability": "",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "",
+        "Moonblast",
+        ""
+      ]
+    }
+  },
+  "Aromatisse": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Relaxed",
+      "ability": "",
+      "item": "Leftovers",
+      "moves": [
+        "",
+        "Moonblast",
+        "",
+        ""
+      ]
+    }
+  },
+  "Slurpuff": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Play Rough",
+        "",
+        "Drain Punch",
+        ""
+      ]
+    }
+  },
+  "Malamar": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Contrary",
+      "item": "Sitrus Berry",
+      "moves": [
+        "Superpower",
+        "Knock Off",
+        "",
+        "Psycho Cut"
+      ]
+    }
+  },
+  "Barbaracle": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Tough Claws",
+      "item": "",
+      "moves": [
+        "Razor Shell",
+        "",
+        "Rock Slide",
+        ""
+      ]
+    }
+  },
+  "Dragalge": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Adaptability",
+      "item": "Choice Specs",
+      "moves": [
+        "Draco Meteor",
+        "Sludge Bomb",
+        "Dragon Pulse",
+        "Hydro Pump"
+      ]
+    }
+  },
+  "Clawitzer": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Mega Launcher",
+      "item": "Assault Vest",
+      "moves": [
+        "Aura Sphere",
+        "Water Pulse",
+        "Dark Pulse",
+        "Ice Beam"
+      ]
+    }
+  },
+  "Heliolisk": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Solar Power",
+      "item": "Choice Specs",
+      "moves": [
+        "Thunderbolt",
+        "Hyper Voice",
+        "Volt Switch",
+        ""
+      ]
+    }
+  },
+  "Tyrunt": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Docile",
+      "ability": "Strong Jaw",
+      "item": "",
+      "moves": [
+        "",
+        "Dragon Claw",
+        "",
+        "Earthquake"
+      ]
+    }
+  },
+  "Tyrantrum": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "Strong Jaw",
+      "item": "Choice Scarf",
+      "moves": [
+        "Ice Fang",
+        "Rock Slide",
+        "Earthquake",
+        "Crunch"
+      ]
+    }
+  },
+  "Aurorus": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Refrigerate",
+      "item": "Life Orb",
+      "moves": [
+        "",
+        "Hyper Voice",
+        "Ancient Power",
+        "Freeze-Dry"
+      ]
+    }
+  },
+  "Sylveon": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Pixilate",
+      "item": "Choice Specs",
+      "moves": [
+        "Hyper Voice",
+        "Shadow Ball",
+        "Psyshock",
+        ""
+      ]
+    }
+  },
+  "Hawlucha": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        "Acrobatics"
+      ]
+    }
+  },
+  "Dedenne": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "",
+        "",
+        "Volt Switch",
+        ""
+      ]
+    }
+  },
+  "Carbink": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Relaxed",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Goomy": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "Flail",
+        ""
+      ]
+    }
+  },
+  "Goodra": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Sap Sipper",
+      "item": "Assault Vest",
+      "moves": [
+        "Dragon Pulse",
+        "Thunderbolt",
+        "Fire Blast",
+        "Sludge Bomb"
+      ]
+    }
+  },
+  "Klefki": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "Foul Play",
+        "",
+        ""
+      ]
+    }
+  },
+  "Trevenant": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Sassy",
+      "ability": "",
+      "item": "Sitrus Berry",
+      "moves": [
+        "",
+        "",
+        "",
+        "Horn Leech"
+      ]
+    }
+  },
+  "Victreebel": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Chlorophyll",
+      "item": "Life Orb",
+      "moves": [
+        "Sludge Bomb",
+        "Weather Ball",
+        "",
+        "Solar Beam"
+      ]
+    }
+  },
+  "Gourgeist-Average": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "",
+      "item": "Choice Scarf",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Gourgeist-Small": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "",
+      "item": "Leftovers",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Gourgeist-Large": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "",
+      "item": "Choice Scarf",
+      "moves": [
+        "",
+        "Phantom Force",
+        "",
+        "Seed Bomb"
+      ]
+    }
+  },
+  "Gourgeist-Super": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Impish",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "Seed Bomb",
+        "",
+        ""
+      ]
+    }
+  },
+  "Avalugg": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Impish",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "Avalanche",
+        "",
+        "",
+        "Earthquake"
+      ]
+    }
+  },
+  "Noivern": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "Draco Meteor",
+        "",
+        "Air Slash",
+        ""
+      ]
+    }
+  },
+  "Tentacruel": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Rain Dish",
+      "item": "Black Sludge",
+      "moves": [
+        "Sludge Bomb",
+        "",
+        "Scald",
+        "Ice Beam"
+      ]
+    }
+  },
+  "Golem": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Brave",
+      "ability": "",
+      "item": "Choice Band",
+      "moves": [
+        "Earthquake",
+        "Rock Slide",
+        "Explosion",
+        "Rock Tomb"
+      ]
+    }
+  },
+  "Rapidash": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "Flash Fire",
+      "item": "Choice Band",
+      "moves": [
+        "Flare Blitz",
+        "Drill Run",
+        "Wild Charge",
+        "Megahorn"
+      ]
+    }
+  },
+  "Slowbro": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "",
+      "item": "Slowbronite",
+      "moves": [
+        "Scald",
+        "",
+        "",
+        "Ice Beam"
+      ]
+    }
+  },
+  "Magnemite": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Bold",
+      "ability": "",
+      "item": "Oran Berry",
+      "moves": [
+        "",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Magneton": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "",
+      "item": "Choice Scarf",
+      "moves": [
+        "Flash Cannon",
+        "",
+        "Volt Switch",
+        "Thunderbolt"
+      ]
+    }
+  },
+  "Farfetch'd": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Impish",
+      "ability": "",
+      "item": "Stick",
+      "moves": [
+        "",
+        "Feint",
+        "",
+        ""
+      ]
+    }
+  },
+  "Seel": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Relaxed",
+      "ability": "Ice Body",
+      "item": "Eviolite",
+      "moves": [
+        "",
+        "Fake Out",
+        "",
+        ""
+      ]
+    }
+  },
+  "Dewgong": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Calm",
+      "ability": "Thick Fat",
+      "item": "Assault Vest",
+      "moves": [
+        "Fake Out",
+        "Icy Wind",
+        "",
+        "Ice Beam"
+      ]
+    }
+  },
+  "Muk": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Adamant",
+      "ability": "",
+      "item": "Black Sludge",
+      "moves": [
+        "",
+        "Shadow Sneak",
+        "Fire Punch",
+        "Gunk Shot"
+      ]
+    }
+  },
+  "Blastoise": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Modest",
+      "ability": "Torrent",
+      "item": "Blastoisinite",
+      "moves": [
+        "Aura Sphere",
+        "Water Spout",
+        "",
+        "Dark Pulse"
+      ]
+    }
+  },
+  "Cloyster": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "Skill Link",
+      "item": "",
+      "moves": [
+        "Icicle Spear",
+        "Rock Blast",
+        "Ice Shard",
+        ""
+      ]
+    }
+  },
+  "Haunter": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Calm",
+      "ability": "Levitate",
+      "item": "Eviolite",
+      "moves": [
+        "Shadow Ball",
+        "",
+        "",
+        ""
+      ]
+    }
+  },
+  "Gengar": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Timid",
+      "ability": "Levitate",
+      "item": "",
+      "moves": [
+        "Sludge Bomb",
+        "",
+        "Shadow Ball",
+        ""
+      ]
+    }
+  },
+  "Hypno": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Relaxed",
+      "ability": "",
+      "item": "",
+      "moves": [
+        "",
+        "",
+        "Psychic",
+        ""
+      ]
+    }
+  },
+  "Kingler": {
+    "Common Battle Spot": {
+      "level": 50,
+      "evs": {},
+      "nature": "Jolly",
+      "ability": "Hyper Cutter",
+      "item": "",
+      "moves": [
+        "",
+        "Crabhammer",
+        "",
+        ""
+      ]
+    }
+  }
+};

--- a/setdex_showdown.js
+++ b/setdex_showdown.js
@@ -1,4 +1,4 @@
-var SETDEX_XY={
+var SETDEX_SHOWDOWN={
   "Swellow": {
     "Common Showdown": {
       "level": 50,

--- a/setdex_showdown.js
+++ b/setdex_showdown.js
@@ -263,7 +263,7 @@ var SETDEX_SHOWDOWN={
       ]
     }
   },
-  "Landorus-Therian": {
+  "Landorus-T": {
     "Common Showdown": {
       "level": 50,
       "evs": {
@@ -1143,7 +1143,7 @@ var SETDEX_SHOWDOWN={
       ]
     }
   },
-  "Rotom-Mow": {
+  "Rotom-C": {
     "Common Showdown": {
       "level": 50,
       "evs": {
@@ -3385,7 +3385,7 @@ var SETDEX_SHOWDOWN={
       ]
     }
   },
-  "Rotom-Frost": {
+  "Rotom-F": {
     "Common Showdown": {
       "level": 50,
       "evs": {
@@ -3517,7 +3517,7 @@ var SETDEX_SHOWDOWN={
       ]
     }
   },
-  "Rotom-Fan": {
+  "Rotom-S": {
     "Common Showdown": {
       "level": 50,
       "evs": {
@@ -3825,7 +3825,7 @@ var SETDEX_SHOWDOWN={
       ]
     }
   },
-  "Rotom-Heat": {
+  "Rotom-H": {
     "Common Showdown": {
       "level": 50,
       "evs": {
@@ -5189,7 +5189,7 @@ var SETDEX_SHOWDOWN={
       ]
     }
   },
-  "Rotom-Wash": {
+  "Rotom-W": {
     "Common Showdown": {
       "level": 50,
       "evs": {
@@ -6047,7 +6047,7 @@ var SETDEX_SHOWDOWN={
       ]
     }
   },
-  "Tornadus-Therian": {
+  "Tornadus-T": {
     "Common Showdown": {
       "level": 50,
       "evs": {
@@ -7719,7 +7719,7 @@ var SETDEX_SHOWDOWN={
       ]
     }
   },
-  "Thundurus-Therian": {
+  "Thundurus-T": {
     "Common Showdown": {
       "level": 50,
       "evs": {

--- a/setdex_xy.js
+++ b/setdex_xy.js
@@ -1,7 +1,7 @@
 var SETDEX_XY = {};
 
 var components = [
-	SETDEX_SMOGVGC
+	SETDEX_SHOWDOWN
 ];
 
 for (var i=0; i<components.length; i++) {

--- a/setdex_xy.js
+++ b/setdex_xy.js
@@ -1,7 +1,8 @@
 var SETDEX_XY = {};
 
 var components = [
-	SETDEX_SHOWDOWN
+	SETDEX_SHOWDOWN,
+    SETDEX_GLOBALLINK
 ];
 
 for (var i=0; i<components.length; i++) {

--- a/setdex_xy.js
+++ b/setdex_xy.js
@@ -1,26 +1,16 @@
-var SETDEX_XY={};
-(function () {
-	var old = {
-		"Abomasnow": {
-			"Placeholder": {
-				"level":50,
-				"evs": {
-					"sa":252,
-					"hp":8,
-					"sp":84,
-					"at":160,
-					"sd":4
-				},
-				"nature":"Lonely",
-				"ability":"Soundproof",
-				"item":"Abomasite",
-				"moves": [
-					"Ice Shard",
-					"Wood Hammer",
-					"Blizzard",
-					"Earthquake"
-				]
+var SETDEX_XY = {};
+
+var components = [
+	SETDEX_SMOGVGC
+];
+
+for (var i=0; i<components.length; i++) {
+	var sourceDex = components[i];
+	if (sourceDex) {
+		for (var p in sourceDex) {
+			if (sourceDex.hasOwnProperty(p)) {
+				SETDEX_XY[p] = $.extend(SETDEX_XY[p], sourceDex[p])
 			}
 		}
-	};
-});
+	}
+}


### PR DESCRIPTION
- Got rid of all references to "smogvgc" in favor of "showdown"
- Added hooks for "globalLink" that aren't populated yet (very soon, though)
- Reworked setdex_xy.js to be able to collate other setdex_\* files as they get added
  - Seems like we can have both auto-generated and "best of NB" manually curated sets, pretty easily

I still want to break the "LevenWork" chunk and then the "showdown" config into their own files, if possible; the gruntfile is already looking kinda ugly, and it's pretty much brand new.  That's a bad sign.
