### PR TITLE
Some Parental Bond optimizations.

### DIFF
--- a/damage.js
+++ b/damage.js
@@ -527,6 +527,17 @@ function getDamageResult(attacker, defender, move, field) {
     
     var damage = [], pbDamage = [];
     var child, childDamage, j;
+    if (attacker.ability === "Parental Bond" && move.hits === 1 && (field.format === "Singles" || !move.isSpread)) {
+        child = JSON.parse(JSON.stringify(attacker));
+        child.ability = '';
+        child.isChild = true;
+        if (move.name === 'Power-Up Punch') {
+            child.boosts[AT]++;
+            child.stats[AT] = getModifiedStat(child.rawStats[AT], child.boosts[AT]);
+        }
+        childDamage = getDamageResult(child, defender, move, field).damage;
+        description.attackerAbility = attacker.ability;
+    }
     for (var i = 0; i < 16; i++) {
         damage[i] = Math.floor(baseDamage * (85 + i) / 100);
         damage[i] = pokeRound(damage[i] * stabMod / 0x1000);
@@ -537,18 +548,9 @@ function getDamageResult(attacker, defender, move, field) {
         damage[i] = Math.max(1, damage[i]);
         damage[i] = pokeRound(damage[i] * finalMod / 0x1000);
         if (attacker.ability === "Parental Bond" && move.hits === 1 && (field.format === "Singles" || !move.isSpread)) {
-            child = JSON.parse(JSON.stringify(attacker));
-            child.ability = '';
-            child.isChild = true;
-            if (move.name === 'Power-Up Punch') {
-                child.boosts[AT]++;
-                child.stats[AT] = getModifiedStat(child.rawStats[AT], child.boosts[AT]);
-            }
-            childDamage = getDamageResult(child, defender, move, field).damage;
             for (j = 0; j < 16; j++) {
                 pbDamage[(16 * i) + j] = damage[i] + childDamage[j];
             }
-            description.attackerAbility = attacker.ability;
         }
     }
     return {"damage": pbDamage.length ? pbDamage.sort() : damage, "description": buildDescription(description)};

--- a/ko_chance.js
+++ b/ko_chance.js
@@ -199,18 +199,25 @@ function getKOChance(damage, multihit, hp, eot, hits, maxHP, toxicCounter, hasSi
         toxicCounter++;
     }
     var sum = 0;
+    var lastC = 0;
     for (i = 0; i < n; i++) {
         if ((hp - damage[i] <= maxHP / 2) && hasSitrus) {
             hp += Math.floor(maxHP / 4);
             hasSitrus = false;
         }
-        var c = getKOChance(damage, multihit, hp - damage[i] + eot - toxicDamage, eot, hits - 1, maxHP, toxicCounter, hasSitrus);
+        var c;
+        if (i === 0 || damage[i] !== damage[i-1]) {
+            c = getKOChance(damage, multihit, hp - damage[i] + eot - toxicDamage, eot, hits - 1, maxHP, toxicCounter, hasSitrus);
+        } else {
+            c = lastC;
+        }
         if (c === 1) {
             sum += (n-i);
             break;
         } else {
             sum += c;
         }
+        lastC = c;
     }
     return sum/n;
 }


### PR DESCRIPTION
In damage.js: Only compute child damage once, since it's independent of parent damage -- still fill out the whole array the way it needs to be.

In ko_chance.js: Don't recompute the recursive KO chance if we've already computed the chance for the same amount of damage on the last time through the loop
