### PR TITLE
Fix Parental Bond sorting issue

### DIFF
--- a/damage.js
+++ b/damage.js
@@ -553,7 +553,11 @@ function getDamageResult(attacker, defender, move, field) {
             }
         }
     }
-    return {"damage": pbDamage.length ? pbDamage.sort() : damage, "description": buildDescription(description)};
+    return {"damage": pbDamage.length ? pbDamage.sort(numericSort) : damage, "description": buildDescription(description)};
+}
+
+function numericSort(a, b) {
+    return a - b;
 }
 
 function buildDescription(description) {


### PR DESCRIPTION
Xleaxgz has pointed out [yet](http://nuggetbridge.com/forums/topic/13623-nugget-bridge-damage-calculator-bugs-feature-requests/page-3#entry180017) [another](http://nuggetbridge.com/forums/topic/13623-nugget-bridge-damage-calculator-bugs-feature-requests/page-3#entry180756) glitch with Mega Kangaskhan:
![screenshot 2015-03-11 at 17 12 37](https://cloud.githubusercontent.com/assets/9887589/6606975/dd2d8d20-c811-11e4-9f92-7ed91f712416.png)

For certain moves the min KO Chance is higher than the max KO Chance. If we take a look at the pbDamage array...
![screenshot 2015-03-11 at 17 17 04](https://cloud.githubusercontent.com/assets/9887589/6607118/ca3f0526-c812-11e4-8e5f-cc4f0d357cbf.png)
...we see that the array isn't being sorted correctly.

By default [].sort() sorts elements [according to each character's Unicode code point value, according to the string conversion of each element.](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort) (oops) 

This commit makes it so the pbDamage array is sorted numerically. The result is:
![screenshot 2015-03-11 at 17 28 28](https://cloud.githubusercontent.com/assets/9887589/6607296/1032251c-c814-11e4-9dca-e16dca851bc5.png)
