### PR TITLE
Explicitly setting lastManualWeather on weather click

### DIFF
--- a/ap_calc.js
+++ b/ap_calc.js
@@ -144,6 +144,9 @@ $("#p2 .ability").bind("keyup change", function() {
 
 var lastManualWeather = "";
 var lastAutoWeather = ["", ""];
+$("input[name='weather']").bind("click", function () {
+    lastManualWeather = $(this).val();
+});
 function autosetWeather(ability, i) {
     var currentWeather = $("input:radio[name='weather']:checked").val();
     if (lastAutoWeather.indexOf(currentWeather) === -1) {


### PR DESCRIPTION
Looks like Honko was intentionally avoiding a solution like this last time around (the git blame suggests it was worked on a bit more than a year ago) -- he was setting lastManualWeather in the setAutoWeather function alone, but that's only _implied_ lastManualWeather.  I've bound the click event to explicitly setting that value, now; but I didn't get rid of his implied-manual code because I didn't want to inadvertently introduce bugs.  I believe that this code is now irrelevant, but don't have time to test:

``` javascript
    if (lastAutoWeather.indexOf(currentWeather) === -1) {
        lastManualWeather = currentWeather;  // This line in particular
        lastAutoWeather[1-i] = "";
    }
```

Addresses #48.
